### PR TITLE
Coveralls fix, install biom-format from conda instead of pip

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,4 @@
+[run]
+relative_files = True
 [report]
 ignore_errors = True

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         uses: AndreMiras/coveralls-python-action@develop
         with:
           parallel: true
-          flag-name: Unit Test
+          flag-name: Run tests and measure coverage
 
   coveralls_finish:
     needs: build

--- a/environment.yml
+++ b/environment.yml
@@ -19,9 +19,9 @@ dependencies:
   - seqtk[version='>=1.4']
   - nose
   - scikit-learn
+  - biom-format
   - flake8
   - pip:
-      - biom-format
       - click
       - coverage
       - coveralls


### PR DESCRIPTION
Something on the jupyterhub server does not like installing `biom-format` via pip; it throws the error described at https://github.com/biocore/biom-format/issues/970 .  The suggested workaround for that issue is to install from conda instead, so trying that.

Also, at some point the coveralls coverage testing got broken, so now it is fixed :)