### PR TITLE
Deploy support for jupyter AND conda prefixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           conda create --yes -n deploytest1 python=${{ matrix.python-version }} git
           conda activate deploytest1
-          bash ./deploy.sh "${{ github.repository }}" "${{ github.ref_name }}"
+          bash ./deploy.sh -r "${{ github.repository }}" -t "${{ github.ref_name }}"
 
   deploy_w_prefix:
     runs-on: ubuntu-latest
@@ -57,4 +57,4 @@ jobs:
           conda activate deploytest2
           # without adding a dummy kernel, can't guarantee location exists
           python -m ipykernel install --name="dummy" --prefix="/home/runner/.local"  
-          bash ./deploy.sh "${{ github.repository }}" "${{ github.ref_name }}" "/home/runner/.local" 
+          bash ./deploy.sh -r "${{ github.repository }}" -t "${{ github.ref_name }}" -j "/home/runner/.local" -c "/home/runner" 

--- a/deploy.sh
+++ b/deploy.sh
@@ -11,7 +11,10 @@
 # bash  ./deploy.sh <repo_name> <tag_name> [kernel_prefix] [--dry-run]
 ##########################################################################
 
-# ensure error codes from upstream calls are passed through pipes
+# -e = exit on error unless in a conditional expression
+# -u = treat unset variables as an error
+# -o pipefail = exit with error if any command in a pipeline fails--
+# ensures error codes from upstream calls are passed through pipes
 set -euo pipefail
 
 # Configuration
@@ -118,7 +121,8 @@ error_exit() {
 check_dependencies() {
   log "INFO" "Checking dependencies..."
   
-  # NB: these are just the dependencies to run this script, not the dependencies for the lab notebooks
+  # NB: these are just the dependencies to run this script, not
+  # the dependencies for the lab notebooks
   for cmd in conda git python; do
     if ! command -v $cmd &> /dev/null; then
       error_exit "Required command not found: $cmd"
@@ -143,28 +147,46 @@ format_kernels_dir() {
 kernel_exists() {
   local kernel_name=$1
 
-  # Check if the kernels directory exists
-  local formatted_kernel_dir=""
-  formatted_kernel_dir=$(format_kernels_dir "$KERNEL_PREFIX")
-  if [[ -n "$formatted_kernel_dir" ]]; then
-    if [ ! -d "$formatted_kernel_dir" ]; then
-        return 1
+  # if jupyter is available, use it to check for kernel existence since it
+  # will look in all the relevant places
+  if command -v jupyter &> /dev/null; then
+    local kernel_names
+    # Extract kernel names
+    kernel_names=$(jupyter kernelspec list | tail -n +2 | awk '{print $1}')
+
+    # Check if kernel_name exists in the list;
+    # -F = fixed string, not regex
+    # -x = matches whole line (exact match)
+    # -q = quiet mode, no output, just exit status
+    if echo "$kernel_names" | grep -Fxq "$kernel_name"; then
+        echo 1 # Kernel exists
+        return 0  # Function succeeded
     fi
+  else
+    # Check just in the specified kernel location, if one was provided
+    local formatted_kernel_dir=""
+    formatted_kernel_dir=$(format_kernels_dir "$KERNEL_PREFIX")
+    if [[ -n "$formatted_kernel_dir" ]]; then
+      if [ ! -d "$formatted_kernel_dir" ]; then
+          # a kernel prefix was specified but it isn't a valid directory
+          return 1
+      fi
 
-    # Get all directories in the kernels directory
-    for dir in "$formatted_kernel_dir"/*; do
-        if [ -d "$dir" ]; then
-            # Extract just the kernel name (basename)
-            local name=""
-            name=$(basename "$dir")
+      # Get all directories in the kernels directory under the specified prefix
+      for dir in "$formatted_kernel_dir"/*; do
+          if [ -d "$dir" ]; then
+              # Extract just the kernel name (basename)
+              local name=""
+              name=$(basename "$dir")
 
-            # Check if it matches the input
-            if [ "$name" = "$kernel_name" ]; then
-                echo 1 # Kernel exists
-                return 0  # Function succeeded
-            fi
-        fi
-    done
+              # Check if it matches the input
+              if [ "$name" = "$kernel_name" ]; then
+                  echo 1 # Kernel exists
+                  return 0  # Function succeeded
+              fi
+          fi
+      done
+    fi
   fi
 
   echo 0 # Kernel does not exist
@@ -176,18 +198,14 @@ setup_new_environment() {
   # Create environment name based on deploy type
   log "INFO" "Setting up new environment '$DEPLOY_NAME'..."
 
+  local conda_install_cmd
+  local repo_install_cmd
+  local kernel_install_cmd
 
-  if [[ -n "$CONDA_PREFIX" ]]; then
-    CONDA_PATH="$CONDA_PREFIX/$DEPLOY_NAME"
-    CONDA_LOC_CMD="--prefix $CONDA_PATH"
-    log "INFO" "Creating conda environment by prefix: $CONDA_PATH"
-  else
-    CONDA_LOC_CMD="--name $DEPLOY_NAME"
-    log "INFO" "Creating conda environment by name: $DEPLOY_NAME"
-  fi
+  log "INFO" "Creating conda environment with ${CONDA_LOC_CMD[*]}"
 
   if [ "$DRY_RUN" = true ]; then
-    log "INFO" "DRY RUN: Would create conda environment '$DEPLOY_NAME'"
+    log "INFO" "DRY RUN: Would create conda environment"
     log "INFO" "DRY_RUN: Would install requirements and repo '$GITHUB_REPO'"
     log "INFO" "DRY_RUN: Would install kernel '$DEPLOY_NAME'"
     return
@@ -199,27 +217,35 @@ setup_new_environment() {
 
   # Note that lightweight cloning (e.g. --depth 1) that leaves out full history only works for lightweight (not annotated) tags
   GITHUB_URL="https://github.com/$GITHUB_REPO"
-  git clone --depth 1 --branch "$DEPLOY_TAG" "$GITHUB_URL" "$TEMP_DIR" || report "Failed to clone repository"
+  git clone --depth 1 --branch "$DEPLOY_TAG" "$GITHUB_URL" "$TEMP_DIR"
 
   # Create new conda environment from environment.yml
   if [ -f "$TEMP_DIR/environment.yml" ]; then
     log "INFO" "Found environment.yml, installing conda environment and dependencies..."
-    conda env create --file "$TEMP_DIR/environment.yml" --name "$DEPLOY_NAME"  || report "Failed to install from environment.yml"
+    conda_install_cmd=(conda env create --file "$TEMP_DIR/environment.yml" "${CONDA_LOC_CMD[@]}")
+    if ! "${conda_install_cmd[@]}"; then
+      report "Failed to install from environment.yml"
+    fi
   else
     report "Could not find environment.yml"
   fi
 
   # Install the repo
   log "INFO" "Installing repo $GITHUB_REPO"
-  conda run -n "$DEPLOY_NAME" pip install "git+$GITHUB_URL@$DEPLOY_TAG" || rollback "Failed to install repo" "$DEPLOY_NAME"
+  repo_install_cmd=(conda run "${CONDA_LOC_CMD[@]}" pip install "git+$GITHUB_URL@$DEPLOY_TAG")
+  if ! "${repo_install_cmd[@]}"; then
+    rollback "Failed to install repo" "$GITHUB_REPO"
+  fi
 
   # Install the kernel; send to user-specified directory iff KERNEL_PREFIX is set else to new conda env
   if [ -z "$KERNEL_PREFIX" ]; then
-    KERNEL_PREFIX=$(conda run -n "$DEPLOY_NAME" python -c 'import sys; print(sys.prefix)')
+    KERNEL_PREFIX=$(conda run "${CONDA_LOC_CMD[@]}" python -c 'import sys; print(sys.prefix)')
   fi
-
-  log "INFO" "Installing kernel $DEPLOY_NAME pointing to environment $DEPLOY_NAME in $KERNEL_PREFIX ..."
-  conda run -n "$DEPLOY_NAME" python -m ipykernel install --name="$DEPLOY_NAME" --display-name="$DEPLOY_NAME" --prefix="$KERNEL_PREFIX" || rollback "Failed to install kernel" "$DEPLOY_NAME"
+  log "INFO" "Installing kernel $DEPLOY_NAME in $KERNEL_PREFIX ..."
+  kernel_install_cmd=(conda run "${CONDA_LOC_CMD[@]}" python -m ipykernel install --name="$DEPLOY_NAME" --display-name="$DEPLOY_NAME" --prefix="$KERNEL_PREFIX")
+  if ! "${kernel_install_cmd[@]}"; then
+    rollback "Failed to install kernel" "$DEPLOY_NAME"
+  fi
 
   # Clean up
   rm -rf "$TEMP_DIR"
@@ -231,14 +257,21 @@ verify_environment() {
   local kernel_name=$2
   
   log "INFO" "Verifying environment '$env_name' and kernel '$kernel_name'..."
-  
+
   # Check if environment exists
-  if ! conda info --envs | awk '{print $1}' | grep -Fxq "$env_name"; then
-    log "ERROR" "Conda environment '$env_name' not found"
-    return 1
+  if [[ -n "$CONDA_PREFIX" ]]; then
+    if [ ! -d "$CONDA_PATH/conda-meta" ]; then
+      log "ERROR" "Conda environment not found at prefix: $CONDA_PATH"
+      return 1
+    fi
+  else
+    if ! conda info --envs | awk '{print $1}' | grep -Fxq "$env_name"; then
+      log "ERROR" "Named conda environment '$env_name' not found"
+      return 1
+    fi
   fi
   
-  # Check if kernel exists
+  # Check if kernel we just tried to create in fact exists now
   log "INFO" "Checking if kernel '$kernel_name' exists for prefix '$KERNEL_PREFIX'..."
   exists=$(kernel_exists "$kernel_name")
   if [ $? -ne 0 ]; then
@@ -248,10 +281,8 @@ verify_environment() {
     log "ERROR" "Kernel '$kernel_name' not found"
     return 1
   fi
-  
-  # Verify kernel can start
-  log "INFO" "Testing if kernel can start..."
-  
+
+  # Create a temporary notebook to verify the kernel
   TEMP_DIR=$(mktemp -d)
   TEMP_NOTEBOOK="$TEMP_DIR/deploy_test.ipynb"
   cat > "$TEMP_NOTEBOOK" << EOF
@@ -282,23 +313,19 @@ EOF
 
   log "INFO" "Executing temporary notebook '$TEMP_NOTEBOOK'..."
 
-  # Activate the conda environment and run the notebook
-  eval "$(conda shell.bash hook)"
-  conda activate "$DEPLOY_NAME"
-
   local return_value
-  if ! jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60 "$TEMP_NOTEBOOK"; then
+  local notebook_cmd=(conda run "${CONDA_LOC_CMD[@]}" jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60 "$TEMP_NOTEBOOK")
+  if ! "${notebook_cmd[@]}"; then
     log "ERROR" "Kernel verification failed - kernel could not execute notebook"
 
     log "WARNING" "Removing kernel '$kernel_name' due to error ..."
-    jupyter kernelspec remove -f "$kernel_name" || log "ERROR" "Failed to clean up kernel '$kernel_name'"
+    jupyter kernelspec remove -f "$kernel_name"
     return_value=1
   else
     log "INFO" "Environment and kernel verification successful"
     return_value=0
   fi
 
-  conda deactivate
   rm -r "$TEMP_DIR"
   return $return_value
 }
@@ -315,8 +342,12 @@ rollback() {
     local deploy_name=$2
 
     log "WARNING" "Removing conda environment '$deploy_name' due to error..."
-    conda remove -n "$deploy_name" --all -y
-    report $message
+    local conda_remove_cmd
+    conda_remove_cmd=(conda env remove "${CONDA_LOC_CMD[@]}" --yes)
+    if ! "${conda_remove_cmd[@]}"; then
+      log "WARNING" "Failed to remove environment with ${CONDA_LOC_CMD[*]}"
+    fi
+    report "$message"
 }
 
 # Main function
@@ -330,6 +361,11 @@ main() {
 
   # Replace literal periods (.) and plus signs (+) in the tag name with underscores (_)
   DEPLOY_NAME=$(echo "$DEPLOY_TAG" | sed 's/[.+]/_/g')
+  CONDA_LOC_CMD=(-n "$DEPLOY_NAME")
+  if [[ -n "$CONDA_PREFIX" ]]; then
+    CONDA_PATH="$CONDA_PREFIX/$DEPLOY_NAME"
+    CONDA_LOC_CMD=(-p "$CONDA_PATH")
+  fi
   
   # Check for existing kernel iff a kernel prefix is provided
   if [[ -n "$KERNEL_PREFIX" ]]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -38,7 +38,7 @@ Optional options:
   -j, --jupyter-prefix <jupyter_dir>  Directory in which to install the Jupyter kernel spec
                                       (e.g., /shared/local). Necessary for installing
                                       kernels to a system-wide shared location.
-  -d, -dry-run                        Show what would happen without making changes
+  -d, --dry-run                        Show what would happen without making changes
   -h, --help                          Show this help message and exit
 
 Examples:
@@ -202,12 +202,13 @@ setup_new_environment() {
   local repo_install_cmd
   local kernel_install_cmd
 
+  # CONDA_LOC_CMD is set in the main function, before this call
   log "INFO" "Creating conda environment with ${CONDA_LOC_CMD[*]}"
 
   if [ "$DRY_RUN" = true ]; then
     log "INFO" "DRY RUN: Would create conda environment"
-    log "INFO" "DRY_RUN: Would install requirements and repo '$GITHUB_REPO'"
-    log "INFO" "DRY_RUN: Would install kernel '$DEPLOY_NAME'"
+    log "INFO" "DRY RUN: Would install requirements and repo '$GITHUB_REPO'"
+    log "INFO" "DRY RUN: Would install kernel '$DEPLOY_NAME'"
     return
   fi
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,7 @@ name: metapool
 channels:
   - bioconda
   - conda-forge
-  - ccbbucsd
-  - r
+  - anaconda
   - defaults
 dependencies:
   - notebook


### PR DESCRIPTION
Turns out that to install on the server, I need to be able to pass in prefixes (paths) for BOTH the jupyter kernel AND the conda environment, so rejiggering of the script was necessary.  Changes here:

* I switched over to tag-based (rather than positional) arguments
* code can now handle getting neither prefix, either one, or both
* more command strings are generated in code rather than hardcoded, to support all the different prefix cases
* improved the error handling to be consistent with running these dynamic command strings and with the `set -e` setting
* extended the kernel search to use jupyter if it can (because it will check all places that the jupyter install looks for kernels)
* got rid of conda env activation before running test notebook and instead changed to running it via `conda run`, as this is less error-prone and handles all activation/deactivation internally
* corrected and expanded comments and logging messages
* removed `ccbbucsd` and `r` channels from environment.yml (they were in the example I wrote this from ;) and added in the `anaconda` channel since Jeff included that in his installs.