### PR TITLE
Centralize sequencers

### DIFF
--- a/metapool/metapool.py
+++ b/metapool/metapool.py
@@ -18,19 +18,13 @@ from .mp_strings import SAMPLE_NAME_KEY, PM_PROJECT_NAME_KEY, \
     get_plate_num_from_plate_name, get_main_project_from_plate_name
 from .plate import _validate_well_id_96, PlateReplication, PlateRemapper, \
     merge_plate_dfs
+from .sequencers import is_i5_revcomp_sequencer
 
 from string import ascii_letters, digits
 import glob
 import xml.etree.ElementTree as ET
 from operator import itemgetter
 from .controls import get_blank_root
-
-# NB: If modifying these lists, see issue ##234!
-REVCOMP_SEQUENCERS = ['HiSeq4000', 'MiniSeq', 'NextSeq', 'HiSeq3000',
-                      'iSeq', 'NovaSeq6000']
-OTHER_SEQUENCERS = ['HiSeq2500', 'HiSeq1500', 'MiSeq', 'NovaSeqX',
-                    'NovaSeqXPlus']
-
 
 INPUT_DNA_KEY = "Input DNA"
 SYNDNA_VOL_KEY = "synDNA volume"
@@ -1514,20 +1508,13 @@ def rc(seq):
 
 
 def sequencer_i5_index(sequencer, indices):
-    if sequencer in REVCOMP_SEQUENCERS:
+    revcomp_i5 = is_i5_revcomp_sequencer(sequencer)
+    if revcomp_i5:
         print("%s: i5 barcodes are output as reverse complements" % sequencer)
         return [rc(x) for x in indices]
-    elif sequencer in OTHER_SEQUENCERS:
+    else:
         print("%s: i5 barcodes are output in standard direction" % sequencer)
         return indices
-    else:
-        raise ValueError(
-            (
-                "Your indicated sequencer [%s] is not recognized.\n"
-                "Recognized sequencers are: \n %s"
-            )
-            % (sequencer, ", ".join(REVCOMP_SEQUENCERS + OTHER_SEQUENCERS))
-        )
 
 
 def reformat_interleaved_to_columns(wells):

--- a/metapool/prep.py
+++ b/metapool/prep.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from glob import glob
 from metapool.mp_strings import get_short_name_and_id
 from metapool.plate import PlateReplication
+from metapool.sequencers import get_model_and_center
 from os import sep, listdir
 from os.path import (basename, isdir, join, split, abspath, exists,
                      normpath)
@@ -58,27 +59,6 @@ AMPLICON_PREP_COLUMN_RENAMER = {
     'Processing Robot': 'processing_robot',
     'sample sheet Sample_ID': 'well_description'
 }
-
-# put together by Gail, based on the instruments we know of
-INSTRUMENT_LOOKUP = pd.DataFrame({
-    'FS10001773': {'machine prefix': 'FS', 'Vocab': 'Illumina iSeq',
-                   'Machine type': 'iSeq', 'run_center': 'KLM'},
-    'A00953': {'machine prefix': 'A', 'Vocab': 'Illumina NovaSeq 6000',
-               'Machine type': 'NovaSeq', 'run_center': 'IGM'},
-    'A00169': {'machine prefix': 'A', 'Vocab': 'Illumina NovaSeq 6000',
-               'Machine type': 'NovaSeq', 'run_center': 'LJI'},
-    'M05314': {'machine prefix': 'M', 'Vocab': 'Illumina MiSeq',
-               'Machine type': 'MiSeq', 'run_center': 'KLM'},
-    'K00180': {'machine prefix': 'K', 'Vocab': 'Illumina HiSeq 4000',
-               'Machine type': 'HiSeq', 'run_center': 'IGM'},
-    'D00611': {'machine prefix': 'D', 'Vocab': 'Illumina HiSeq 2500',
-               'Machine type': 'HiSeq/RR', 'run_center': 'IGM'},
-    'LH00444': {'machine prefix': 'LH', 'Vocab': 'Illumina NovaSeq X',
-                'Machine type': 'NovaSeq', 'run_center': 'IGM'},
-    'SH00252': {'machine prefix': 'SH', 'Vocab': 'Illumina MiSeq i100',
-                'Machine type': 'MiSeq i100', 'run_center': 'IGM'},
-    'MN01225': {'machine prefix': 'MN', 'Vocab': 'Illumina MiniSeq',
-                'Machine type': 'MiniSeq', 'run_center': 'CMI'}}).T
 
 
 def parse_illumina_run_id(run_id):
@@ -184,60 +164,60 @@ def _exists_and_has_files(path):
     return exists(path) and len(_file_list(path))
 
 
-def get_machine_code(instrument_model):
-    """Get the machine code for an instrument's code
-
-    Parameters
-    ----------
-    instrument_model: str
-        An instrument's model of the form A999999 or AA999999
-
-    Returns
-    -------
-    """
-    # the machine code represents the first 1 to 2 letters of the
-    # instrument model
-    machine_code = re.compile(r'^([a-zA-Z]{1,2})')
-    matches = re.search(machine_code, instrument_model)
-    if matches is None:
-        raise ValueError('Cannot find a machine code. This instrument '
-                         'model is malformed %s. The machine code is a '
-                         'one or two character prefix.' % instrument_model)
-    return matches[0]
-
-
-def get_model_and_center(instrument_code):
-    """Determine instrument model and center based on a lookup
-
-    Parameters
-    ----------
-    instrument_code: str
-        Instrument code from a run identifier.
-
-    Returns
-    -------
-    str
-        Instrument model.
-    str
-        Run center based on the machine's id.
-    """
-    run_center = "UCSDMI"
-    instrument_model = instrument_code.split('_')[0]
-
-    if instrument_model in INSTRUMENT_LOOKUP.index:
-        run_center = INSTRUMENT_LOOKUP.loc[instrument_model, 'run_center']
-        instrument_model = INSTRUMENT_LOOKUP.loc[instrument_model, 'Vocab']
-    else:
-        instrument_prefix = get_machine_code(instrument_model)
-
-        if instrument_prefix not in INSTRUMENT_LOOKUP['machine prefix']:
-            ValueError('Unrecognized machine prefix %s' % instrument_prefix)
-
-        instrument_model = INSTRUMENT_LOOKUP[
-            INSTRUMENT_LOOKUP['machine prefix'] == instrument_prefix
-            ]['Vocab'].unique()[0]
-
-    return instrument_model, run_center
+# def get_machine_code(instrument_model):
+#     """Get the machine code for an instrument's code
+#
+#     Parameters
+#     ----------
+#     instrument_model: str
+#         An instrument's model of the form A999999 or AA999999
+#
+#     Returns
+#     -------
+#     """
+#     # the machine code represents the first 1 to 2 letters of the
+#     # instrument model
+#     machine_code = re.compile(r'^([a-zA-Z]{1,2})')
+#     matches = re.search(machine_code, instrument_model)
+#     if matches is None:
+#         raise ValueError('Cannot find a machine code. This instrument '
+#                          'model is malformed %s. The machine code is a '
+#                          'one or two character prefix.' % instrument_model)
+#     return matches[0]
+#
+#
+# def get_model_and_center(instrument_code):
+#     """Determine instrument model and center based on a lookup
+#
+#     Parameters
+#     ----------
+#     instrument_code: str
+#         Instrument code from a run identifier.
+#
+#     Returns
+#     -------
+#     str
+#         Instrument model.
+#     str
+#         Run center based on the machine's id.
+#     """
+#     run_center = "UCSDMI"
+#     instrument_model = instrument_code.split('_')[0]
+#
+#     if instrument_model in INSTRUMENT_LOOKUP.index:
+#         run_center = INSTRUMENT_LOOKUP.loc[instrument_model, 'run_center']
+#         instrument_model = INSTRUMENT_LOOKUP.loc[instrument_model, 'Vocab']
+#     else:
+#         instrument_prefix = get_machine_code(instrument_model)
+#
+#         if instrument_prefix not in INSTRUMENT_LOOKUP['machine prefix']:
+#             ValueError('Unrecognized machine prefix %s' % instrument_prefix)
+#
+#         instrument_model = INSTRUMENT_LOOKUP[
+#             INSTRUMENT_LOOKUP['machine prefix'] == instrument_prefix
+#             ]['Vocab'].unique()[0]
+#
+#     return instrument_model, run_center
 
 
 def agp_transform(frame, study_id):

--- a/metapool/prep.py
+++ b/metapool/prep.py
@@ -164,62 +164,6 @@ def _exists_and_has_files(path):
     return exists(path) and len(_file_list(path))
 
 
-# def get_machine_code(instrument_model):
-#     """Get the machine code for an instrument's code
-#
-#     Parameters
-#     ----------
-#     instrument_model: str
-#         An instrument's model of the form A999999 or AA999999
-#
-#     Returns
-#     -------
-#     """
-#     # the machine code represents the first 1 to 2 letters of the
-#     # instrument model
-#     machine_code = re.compile(r'^([a-zA-Z]{1,2})')
-#     matches = re.search(machine_code, instrument_model)
-#     if matches is None:
-#         raise ValueError('Cannot find a machine code. This instrument '
-#                          'model is malformed %s. The machine code is a '
-#                          'one or two character prefix.' % instrument_model)
-#     return matches[0]
-#
-#
-# def get_model_and_center(instrument_code):
-#     """Determine instrument model and center based on a lookup
-#
-#     Parameters
-#     ----------
-#     instrument_code: str
-#         Instrument code from a run identifier.
-#
-#     Returns
-#     -------
-#     str
-#         Instrument model.
-#     str
-#         Run center based on the machine's id.
-#     """
-#     run_center = "UCSDMI"
-#     instrument_model = instrument_code.split('_')[0]
-#
-#     if instrument_model in INSTRUMENT_LOOKUP.index:
-#         run_center = INSTRUMENT_LOOKUP.loc[instrument_model, 'run_center']
-#         instrument_model = INSTRUMENT_LOOKUP.loc[instrument_model, 'Vocab']
-#     else:
-#         instrument_prefix = get_machine_code(instrument_model)
-#
-#         if instrument_prefix not in INSTRUMENT_LOOKUP['machine prefix']:
-#             ValueError('Unrecognized machine prefix %s' % instrument_prefix)
-#
-#         instrument_model = INSTRUMENT_LOOKUP[
-#             INSTRUMENT_LOOKUP['machine prefix'] == instrument_prefix
-#             ]['Vocab'].unique()[0]
-#
-#     return instrument_model, run_center
-
-
 def agp_transform(frame, study_id):
     """If the prep belongs to the American Gut Project fill in some blanks
 

--- a/metapool/sequencers.py
+++ b/metapool/sequencers.py
@@ -32,13 +32,66 @@ _INSTRUMENT_LOOKUP = pandas.DataFrame({
     'MN01225': {_MODEL_TYPE_KEY: 'MiniSeq', _RUN_CENTER_KEY: 'CMI'}}).T
 
 
+def _deep_freeze(obj):
+    """Recursively freeze a Python object to make it immutable.
+    This function converts mutable objects (dicts, lists, sets) into their
+    immutable counterparts (MappingProxyType, tuples, frozensets) while
+    leaving immutable objects (strings, numbers, etc.) unchanged.
+
+    Parameters
+    ----------
+    obj: Any
+        The object to freeze. It can be a dict, list, set, tuple, or any
+        immutable type (like str, int, float, etc.).
+
+    Returns
+    -------
+    Any
+        An immutable version of the input object. If the input is a dict,
+        it returns a MappingProxyType; if it's a list, it returns a tuple;
+        if it's a set, it returns a frozenset; otherwise, it returns the
+        original object unchanged.
+    """
+    if isinstance(obj, dict):
+        # Recursively freeze values and return a read-only MappingProxyType
+        return MappingProxyType({k: _deep_freeze(v) for k, v in obj.items()})
+    elif isinstance(obj, list):
+        # Convert list to tuple after freezing elements
+        return tuple(_deep_freeze(v) for v in obj)
+    elif isinstance(obj, set):
+        # Convert set to frozenset after freezing elements
+        return frozenset(_deep_freeze(v) for v in obj)
+    elif isinstance(obj, tuple):
+        # Freeze all elements in the tuple
+        return tuple(_deep_freeze(v) for v in obj)
+    else:
+        # Assume everything else is immutable
+        return obj
+
+
 def _load_sequencer_types(existing_types=None, test_only_fp=None):
-    """Load sequencer types from yaml file.
+    """Load sequencer types from sequencer types yaml file.
+
+    Parameters
+    ----------
+    existing_types: MappingProxyType, optional
+        A mapping of sequencer types to use instead of loading from file.
+        If None, the sequencer types will be loaded from the YAML file; if
+        provided, will short-circuit the loading process and return input.
+    test_only_fp: str, optional
+        For testing purposes ONLY, a test file path to load the sequencer
+        types from. If None, the default sequencer types YAML file will be
+        used; should always be None in production code.
 
     Returns
     -------
     MappingProxyType
         Immutable dictionary of sequencer types.
+
+    Raises
+    ------
+    ValueError
+        If existing_types is not a MappingProxyType or None.
     """
 
     if existing_types is not None:
@@ -46,26 +99,29 @@ def _load_sequencer_types(existing_types=None, test_only_fp=None):
         if not isinstance(existing_types, MappingProxyType):
             raise ValueError(
                 "existing_types must be a MappingProxyType or None.")
-        return existing_types
+        # end if existing_types is not a MappingProxyType
 
-    if test_only_fp is None:
-        # get the path to the directory above the one this file is in
-        grandmom_dir = \
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        sequencers_fp = os.path.join(grandmom_dir, _SEQUENCER_TYPES_YML_FNAME)
+        sequencer_types = existing_types
     else:
-        # for testing, use the provided file path
-        sequencers_fp = test_only_fp
+        if test_only_fp is None:
+            # get the path to the directory above the one this file is in
+            grandmom_dir = \
+                os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            sequencers_fp = os.path.join(grandmom_dir, _SEQUENCER_TYPES_YML_FNAME)
+        else:
+            # for testing, use the provided file path
+            sequencers_fp = test_only_fp
 
-    with open(sequencers_fp, 'r') as file:
-        sequencer_types = yaml.safe_load(file)
+        with open(sequencers_fp, 'r') as file:
+            sequencer_types = yaml.safe_load(file)
+    # end if existing_types is None or not
 
-    immutable_sequencer_types = MappingProxyType(sequencer_types)
+    immutable_sequencer_types = _deep_freeze(sequencer_types)
     return immutable_sequencer_types
 
 
 def _get_machine_code(instrument_model):
-    """Get the machine code for an instrument's code
+    """Get the machine code for an instrument's model string
 
     Parameters
     ----------
@@ -74,6 +130,15 @@ def _get_machine_code(instrument_model):
 
     Returns
     -------
+    str
+        The machine code, which is the first 1 or 2 letters of the instrument
+        model.
+
+    Raises
+    ------
+    ValueError
+        If the instrument model is malformed and does not contain a valid
+        machine code.
     """
     # the machine code represents the first 1 to 2 letters of the
     # instrument model
@@ -87,7 +152,7 @@ def _get_machine_code(instrument_model):
 
 
 def get_model_and_center(instrument_code):
-    """Determine instrument model and center based on a lookup
+    """Determine instrument model and center using instrument code.
 
     Parameters
     ----------
@@ -99,7 +164,13 @@ def get_model_and_center(instrument_code):
     str
         Instrument model.
     str
-        Run center based on the machine's id.
+        Run center associated with the instrument.
+
+    Raises
+    ------
+    ValueError
+        If zero or more than one machine prefixes are associated with
+        the instrument code.
     """
 
     run_center = _LAB_RUN_CENTER  # Default run center for lab data
@@ -132,7 +203,7 @@ def get_model_and_center(instrument_code):
 
 
 def get_sequencers_w_key_value(key, value, default=None, existing_types=None):
-    """Get sequencers with a specific key-value pair.
+    """Get all sequencers with a specific key-value pair.
 
     Parameters
     ----------
@@ -151,26 +222,44 @@ def get_sequencers_w_key_value(key, value, default=None, existing_types=None):
     -------
     MappingProxyType
         Immutable dictionary of sequencer types that match the key-value pair.
+
+    Raises
+    ------
+    ValueError
+        If the info for a sequencer type is not a dictionary.
     """
 
     found_sequencers = {}
     sequencer_types = _load_sequencer_types(existing_types)
     for name, details in sequencer_types.items():
-        if not isinstance(details, dict):
+        if not isinstance(details, MappingProxyType):
             raise ValueError(
-                f"Info for sequencer type '{name}' is not a dictionary.")
+                f"Info for sequencer type '{name}' is not a MappingProxyType.")
         found_value = details.get(key, default)
         if found_value == value:
             found_sequencers[name] = details
         # if this sequencer has the desired key-value pair
     # next sequencer type
 
-    immutable_found_sequencers = MappingProxyType(found_sequencers)
+    immutable_found_sequencers = _deep_freeze(found_sequencers)
     return immutable_found_sequencers
 
 
 def get_i5_index_sequencers(existing_types=None):
-    """Get sequencer types that use an i5 index, revcomped or not."""
+    """Get sequencer types that use an i5 index, revcomped or not.
+
+    Parameters
+    ----------
+    existing_types: MappingProxyType, optional
+        A mapping of available sequencer types. If None, the
+        sequencer types will be loaded from the YAML file.
+
+    Returns
+    -------
+    MappingProxyType
+        Immutable dictionary of sequencer types that use an i5 index, with or
+        without revcomping.
+    """
     result = MappingProxyType({})
     available_sequencer_types = _load_sequencer_types(existing_types)
     for curr_bool_val in [True, False]:
@@ -197,10 +286,15 @@ def get_sequencer_type(sequencer_type, existing_types=None):
     -------
     MappingProxyType
         Immutable dictionary of the sequencer type details.
+
+    Raises
+    ------
+    ValueError
+        If the sequencer type is not found in the available sequencer types.
     """
     sequencer_types = _load_sequencer_types(existing_types)
     if sequencer_type in sequencer_types:
-        return MappingProxyType(sequencer_types[sequencer_type])
+        return _deep_freeze(sequencer_types[sequencer_type])
     # end if sequencer type is in the available sequencers
 
     # if we get here, the sequencer type is not found
@@ -208,7 +302,27 @@ def get_sequencer_type(sequencer_type, existing_types=None):
 
 
 def is_i5_revcomp_sequencer(sequencer_type, existing_types=None):
-    """Check if a sequencer type uses a revcomp i5 index in sample sheet."""
+    """Check if sequencer type uses a revcomped i5 index in sample sheets.
+
+    Parameters
+    ----------
+    sequencer_type: str
+        The name of the sequencer type to check.
+    existing_types: MappingProxyType, optional
+        A mapping of available sequencer types. If None, the
+        sequencer types will be loaded from the YAML file.
+
+    Returns
+    -------
+    bool
+        True if the sequencer type uses a revcomped i5 index, False otherwise.
+
+    Raises
+    ------
+    ValueError
+        If the sequencer type does not have a revcomp i5 key in the sequencer
+        types.
+    """
     sequencer_info = get_sequencer_type(
         sequencer_type, existing_types=existing_types)
     if _REVCOMP_I5_KEY in sequencer_info:

--- a/metapool/sequencers.py
+++ b/metapool/sequencers.py
@@ -1,0 +1,221 @@
+import os
+import pandas
+import re
+from types import MappingProxyType
+import yaml
+
+DELETE_SETTINGS_KEY = "delete_settings"
+
+_MACHINE_PREFIX_KEY = 'machine_prefix'
+_MODEL_TYPE_KEY = 'model'
+_MODEL_NAME_KEY = 'model_name'
+_RUN_CENTER_KEY = 'run_center'
+_REVCOMP_I5_KEY = "revcomp_samplesheet_i5_index"
+
+_LAB_RUN_CENTER = "UCSDMI"
+_SEQUENCER_TYPES_YML_FNAME = 'sequencer_types.yml'
+
+# DEPRECATED: We no longer want to identify sequencer types by the
+# instrument id, since that requires a change for every new physical machine.
+# This is kept for backwards compatibility with existing data, but for anything
+# new, we should use the instrument type instead.
+# _MODEL_TYPE_KEY values must match up to a key in the sequencer_types.yml file.
+_INSTRUMENT_LOOKUP = pandas.DataFrame({
+    'FS10001773': {_MODEL_TYPE_KEY: 'iSeq', _RUN_CENTER_KEY: 'KLM'},
+    'A00953': {_MODEL_TYPE_KEY: 'NovaSeq6000', _RUN_CENTER_KEY: 'IGM'},
+    'A00169': {_MODEL_TYPE_KEY: 'NovaSeq6000', _RUN_CENTER_KEY: 'LJI'},
+    'M05314': {_MODEL_TYPE_KEY: 'MiSeq', _RUN_CENTER_KEY: 'KLM'},
+    'K00180': {_MODEL_TYPE_KEY: 'HiSeq4000', _RUN_CENTER_KEY: 'IGM'},
+    'D00611': {_MODEL_TYPE_KEY: 'HiSeq2500', _RUN_CENTER_KEY: 'IGM'},
+    'LH00444': {_MODEL_TYPE_KEY: 'NovaSeqX', _RUN_CENTER_KEY: 'IGM'},
+    'SH00252': {_MODEL_TYPE_KEY: 'MiSeqi100', _RUN_CENTER_KEY: 'IGM'},
+    'MN01225': {_MODEL_TYPE_KEY: 'MiniSeq', _RUN_CENTER_KEY: 'CMI'}}).T
+
+
+def _load_sequencer_types(existing_types=None, test_only_fp=None):
+    """Load sequencer types from yaml file.
+
+    Returns
+    -------
+    MappingProxyType
+        Immutable dictionary of sequencer types.
+    """
+
+    if existing_types is not None:
+        # if an existing mapping is provided, use it
+        if not isinstance(existing_types, MappingProxyType):
+            raise ValueError(
+                "existing_types must be a MappingProxyType or None.")
+        return existing_types
+
+    if test_only_fp is None:
+        # get the path to the directory above the one this file is in
+        grandmom_dir = \
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        sequencers_fp = os.path.join(grandmom_dir, _SEQUENCER_TYPES_YML_FNAME)
+    else:
+        # for testing, use the provided file path
+        sequencers_fp = test_only_fp
+
+    with open(sequencers_fp, 'r') as file:
+        sequencer_types = yaml.safe_load(file)
+
+    immutable_sequencer_types = MappingProxyType(sequencer_types)
+    return immutable_sequencer_types
+
+
+def _get_machine_code(instrument_model):
+    """Get the machine code for an instrument's code
+
+    Parameters
+    ----------
+    instrument_model: str
+        An instrument's model of the form A999999 or AA999999
+
+    Returns
+    -------
+    """
+    # the machine code represents the first 1 to 2 letters of the
+    # instrument model
+    machine_code = re.compile(r'^([a-zA-Z]{1,2})')
+    matches = re.search(machine_code, instrument_model)
+    if matches is None:
+        raise ValueError('Cannot find a machine code. This instrument '
+                         'model is malformed %s. The machine code is a '
+                         'one or two character prefix.' % instrument_model)
+    return matches[0]
+
+
+def get_model_and_center(instrument_code):
+    """Determine instrument model and center based on a lookup
+
+    Parameters
+    ----------
+    instrument_code: str
+        Instrument code from a run identifier.
+
+    Returns
+    -------
+    str
+        Instrument model.
+    str
+        Run center based on the machine's id.
+    """
+
+    run_center = _LAB_RUN_CENTER  # Default run center for lab data
+    available_sequencer_types = _load_sequencer_types()
+
+    instrument_id = instrument_code.split('_')[0]
+    if instrument_id in _INSTRUMENT_LOOKUP.index:
+        run_center = _INSTRUMENT_LOOKUP.loc[instrument_id, _RUN_CENTER_KEY]
+        inst_model_type = _INSTRUMENT_LOOKUP.loc[instrument_id, _MODEL_TYPE_KEY]
+    else:
+        instrument_prefix = _get_machine_code(instrument_id)
+        models_w_prefix = get_sequencers_w_key_value(
+            _MACHINE_PREFIX_KEY, instrument_prefix,
+            existing_types=available_sequencer_types)
+        if len(models_w_prefix) == 0:
+            raise ValueError(
+                f"Unrecognized {_MACHINE_PREFIX_KEY} {instrument_prefix}")
+        elif len(models_w_prefix) > 1:
+            raise ValueError(
+                f"Found {len(models_w_prefix)} sequencers found with "
+                f"{_MACHINE_PREFIX_KEY} = '{instrument_prefix}'.")
+        # end if got an unexpected number of sequencer types w given prefix
+        inst_model_type = next(iter(models_w_prefix))
+    # end if instrument_id is in the lookup or if must look up by prefix
+
+    inst_sequencer_type = available_sequencer_types[inst_model_type]
+    instrument_model = inst_sequencer_type[_MODEL_NAME_KEY]
+
+    return instrument_model, run_center
+
+
+def get_sequencers_w_key_value(key, value, default=None, existing_types=None):
+    """Get sequencers with a specific key-value pair.
+
+    Parameters
+    ----------
+    key: str
+        The key to search for in the sequencer types.
+    value: object
+        The value to match for the given key.
+    default: object, optional
+        The default to use as value if key is not found in a sequencer type.
+        Defaults to None.
+    existing_types: MappingProxyType, optional
+        A mapping of sequencer types to search in. If None, the
+        sequencer types will be loaded from the YAML file.
+
+    Returns
+    -------
+    MappingProxyType
+        Immutable dictionary of sequencer types that match the key-value pair.
+    """
+
+    found_sequencers = {}
+    sequencer_types = _load_sequencer_types(existing_types)
+    for name, details in sequencer_types.items():
+        if not isinstance(details, dict):
+            raise ValueError(
+                f"Info for sequencer type '{name}' is not a dictionary.")
+        found_value = details.get(key, default)
+        if found_value == value:
+            found_sequencers[name] = details
+        # if this sequencer has the desired key-value pair
+    # next sequencer type
+
+    immutable_found_sequencers = MappingProxyType(found_sequencers)
+    return immutable_found_sequencers
+
+
+def get_i5_index_sequencers(existing_types=None):
+    """Get sequencer types that use an i5 index, revcomped or not."""
+    result = MappingProxyType({})
+    available_sequencer_types = _load_sequencer_types(existing_types)
+    for curr_bool_val in [True, False]:
+        curr_mapping_proxy = get_sequencers_w_key_value(
+            _REVCOMP_I5_KEY, curr_bool_val,
+            existing_types=available_sequencer_types)
+        result = MappingProxyType(result | curr_mapping_proxy)
+    # next boolean value
+    return result
+
+
+def get_sequencer_type(sequencer_type, existing_types=None):
+    """Get the sequencer type info from the available sequencer types.
+
+    Parameters
+    ----------
+    sequencer_type: str
+        The name of the sequencer type to retrieve.
+    existing_types: MappingProxyType, optional
+        A mapping of available sequencer types. If None, the
+        sequencer types will be loaded from the YAML file.
+
+    Returns
+    -------
+    MappingProxyType
+        Immutable dictionary of the sequencer type details.
+    """
+    sequencer_types = _load_sequencer_types(existing_types)
+    if sequencer_type in sequencer_types:
+        return MappingProxyType(sequencer_types[sequencer_type])
+    # end if sequencer type is in the available sequencers
+
+    # if we get here, the sequencer type is not found
+    raise ValueError(f"Sequencer type '{sequencer_type}' not found.")
+
+
+def is_i5_revcomp_sequencer(sequencer_type, existing_types=None):
+    """Check if a sequencer type uses a revcomp i5 index in sample sheet."""
+    sequencer_info = get_sequencer_type(
+        sequencer_type, existing_types=existing_types)
+    if _REVCOMP_I5_KEY in sequencer_info:
+        return sequencer_info[_REVCOMP_I5_KEY]
+    # end if sequencer type has the revcomp i5 key
+
+    # if we get here, the sequencer type is not in the i5 index sequencers
+    raise ValueError(
+        f"Sequencer type '{sequencer_type}' does not have a "
+        f"'{_REVCOMP_I5_KEY}' key in sequencer types.")

--- a/metapool/sequencers.py
+++ b/metapool/sequencers.py
@@ -19,7 +19,7 @@ _SEQUENCER_TYPES_YML_FNAME = 'sequencer_types.yml'
 # instrument id, since that requires a change for every new physical machine.
 # This is kept for backwards compatibility with existing data, but for anything
 # new, we should use the instrument type instead.
-# _MODEL_TYPE_KEY values must match up to a key in the sequencer_types.yml file.
+# _MODEL_TYPE_KEY values must match to a key in the sequencer_types.yml file.
 _INSTRUMENT_LOOKUP = pandas.DataFrame({
     'FS10001773': {_MODEL_TYPE_KEY: 'iSeq', _RUN_CENTER_KEY: 'KLM'},
     'A00953': {_MODEL_TYPE_KEY: 'NovaSeq6000', _RUN_CENTER_KEY: 'IGM'},
@@ -107,7 +107,8 @@ def _load_sequencer_types(existing_types=None, test_only_fp=None):
             # get the path to the directory above the one this file is in
             grandmom_dir = \
                 os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-            sequencers_fp = os.path.join(grandmom_dir, _SEQUENCER_TYPES_YML_FNAME)
+            sequencers_fp = os.path.join(
+                grandmom_dir, _SEQUENCER_TYPES_YML_FNAME)
         else:
             # for testing, use the provided file path
             sequencers_fp = test_only_fp
@@ -179,7 +180,8 @@ def get_model_and_center(instrument_code):
     instrument_id = instrument_code.split('_')[0]
     if instrument_id in _INSTRUMENT_LOOKUP.index:
         run_center = _INSTRUMENT_LOOKUP.loc[instrument_id, _RUN_CENTER_KEY]
-        inst_model_type = _INSTRUMENT_LOOKUP.loc[instrument_id, _MODEL_TYPE_KEY]
+        inst_model_type = _INSTRUMENT_LOOKUP.loc[
+            instrument_id, _MODEL_TYPE_KEY]
     else:
         instrument_prefix = _get_machine_code(instrument_id)
         models_w_prefix = get_sequencers_w_key_value(

--- a/metapool/tests/data/test_only_sequencers.yml
+++ b/metapool/tests/data/test_only_sequencers.yml
@@ -1,0 +1,8 @@
+NovaSeqX:
+    model_name: 'Illumina NovaSeq X'
+    revcomp_samplesheet_i5_index: false
+    machine_prefix: 'LH'
+NovaSeqXPlus:
+    model_name: 'Illumina NovaSeq X Plus'
+    revcomp_samplesheet_i5_index: false
+    machine_prefix: 'LH'

--- a/metapool/tests/test_prep.py
+++ b/metapool/tests/test_prep.py
@@ -1,5 +1,5 @@
 from os.path import join, dirname, exists
-from os import makedirs
+from os import makedirs, path
 from shutil import rmtree
 import pandas as pd
 from random import choice, randint, shuffle
@@ -10,7 +10,6 @@ from metapool.sample_sheet import (MetagenomicSampleSheetv90,
                                    sample_sheet_to_dataframe)
 from metapool.prep import (preparations_for_run, remove_qiita_id,
                            get_run_prefix,
-                           get_machine_code, get_model_and_center,
                            parse_illumina_run_id,
                            _check_invalid_names, agp_transform, parse_prep,
                            generate_qiita_prep_file, qiita_scrub_name,
@@ -357,48 +356,6 @@ class TestPrep(TestCase):
         for bad in bad_entries:
             with self.assertRaises(ValueError):
                 parse_illumina_run_id(bad)
-
-    def test_machine_code(self):
-        obs = get_machine_code('K00180')
-        self.assertEqual(obs, 'K')
-
-        obs = get_machine_code('D00611')
-        self.assertEqual(obs, 'D')
-
-        obs = get_machine_code('MN01225')
-        self.assertEqual(obs, 'MN')
-
-        with self.assertRaisesRegex(ValueError,
-                                    'Cannot find a machine code. This '
-                                    'instrument model is malformed 8675309. '
-                                    'The machine code is a one or two '
-                                    'character prefix.'):
-            get_machine_code('8675309')
-
-    def test_get_model_and_center(self):
-        obs = get_model_and_center('D32611_0365_G00DHB5YXX')
-        self.assertEqual(obs, ('Illumina HiSeq 2500', 'UCSDMI'))
-
-        obs = get_model_and_center('A86753_0365_G00DHB5YXX')
-        self.assertEqual(obs, ('Illumina NovaSeq 6000', 'UCSDMI'))
-
-        obs = get_model_and_center('A00953_0032_AHWMGJDDXX')
-        self.assertEqual(obs, ('Illumina NovaSeq 6000', 'IGM'))
-
-        obs = get_model_and_center('A00169_8131_AHKXYNDHXX')
-        self.assertEqual(obs, ('Illumina NovaSeq 6000', 'LJI'))
-
-        obs = get_model_and_center('M05314_0255_000000000-J46T9')
-        self.assertEqual(obs, ('Illumina MiSeq', 'KLM'))
-
-        obs = get_model_and_center('K00180_0957_AHCYKKBBXY')
-        self.assertEqual(obs, ('Illumina HiSeq 4000', 'IGM'))
-
-        obs = get_model_and_center('D00611_0712_BH37W2BCX3_RKL0040')
-        self.assertEqual(obs, ('Illumina HiSeq 2500', 'IGM'))
-
-        obs = get_model_and_center('MN01225_0002_A000H2W3FY')
-        self.assertEqual(obs, ('Illumina MiniSeq', 'CMI'))
 
     def test_agp_transform(self):
         columns = ['sample_name', 'experiment_design_description',
@@ -1934,7 +1891,7 @@ class TestPrep(TestCase):
 
 class TestPrePrepReplicates(TestCase):
     def setUp(self):
-        self.data_dir = join('metapool', 'tests', 'data')
+        self.data_dir = path.join(path.dirname(__file__), 'data')
         self.prep_w_replicates_path = join(self.data_dir,
                                            'pre_prep_w_replicates.csv')
         self.prep_wo_replicates_path = join(self.data_dir,

--- a/metapool/tests/test_sequencers.py
+++ b/metapool/tests/test_sequencers.py
@@ -89,7 +89,8 @@ class TestSequencers(TestCase):
         })
 
         obs = get_sequencers_w_key_value(
-            'revcomp_samplesheet_i5_index', False, existing_types=external_mapping)
+            'revcomp_samplesheet_i5_index', False,
+            existing_types=external_mapping)
         self.assertEqual(len(obs), 2)
         self.assertIn('HiSeq2500', obs)
         self.assertIn('MiniSeq', obs)
@@ -165,7 +166,8 @@ class TestSequencers(TestCase):
             }
         })
 
-        obs = get_sequencer_type('NovaSeq6000', existing_types=external_mapping)
+        obs = get_sequencer_type(
+            'NovaSeq6000', existing_types=external_mapping)
         self.assertEqual(len(obs), 3)
         self.assertEqual(obs['machine_prefix'], 'A')
         self.assertEqual(obs['model_name'], 'Illumina NovaSeq 6000')

--- a/metapool/tests/test_sequencers.py
+++ b/metapool/tests/test_sequencers.py
@@ -74,7 +74,10 @@ class TestSequencers(TestCase):
             "MiniSeq": {
                 'machine_prefix': 'MN',
                 'model_name': 'Illumina MiniSeq',
-                'revcomp_samplesheet_i5_index': False
+                'revcomp_samplesheet_i5_index': False,
+                # extra key here that is present only for this sequencer
+                # and not for others
+                'delete_settings': ["MaskShortReads", "OverrideCycles"]
             },
             "NovaSeq6000": {
                 'machine_prefix': 'A',
@@ -85,6 +88,12 @@ class TestSequencers(TestCase):
                 'machine_prefix': 'D',
                 'model_name': 'Illumina HiSeq 2500',
                 'revcomp_samplesheet_i5_index': False
+            },
+            "HiSeq3000": {
+                'machine_prefix': 'H',
+                'model_name': 'Illumina HiSeq 3000',
+                # No revcomp_samplesheet_i5_index key here, showing keys can
+                # be omitted when not relevant
             }
         })
 
@@ -93,7 +102,9 @@ class TestSequencers(TestCase):
             existing_types=external_mapping)
         self.assertEqual(len(obs), 2)
         self.assertIn('HiSeq2500', obs)
+        self.assertEqual(len(obs['HiSeq2500']), 3)
         self.assertIn('MiniSeq', obs)
+        self.assertEqual(len(obs['MiniSeq']), 4)
 
     def test_get_sequencers_w_key_value_err_malformed_mapping(self):
         """Test error getting sequencers w key-value pair in bad mapping."""

--- a/metapool/tests/test_sequencers.py
+++ b/metapool/tests/test_sequencers.py
@@ -1,0 +1,209 @@
+from metapool.sequencers import _get_machine_code, get_model_and_center, \
+    get_sequencers_w_key_value, get_i5_index_sequencers, get_sequencer_type, \
+    is_i5_revcomp_sequencer
+from types import MappingProxyType
+from unittest import TestCase, main
+
+
+class TestSequencers(TestCase):
+    def test__get_machine_code(self):
+        obs = _get_machine_code('K00180')
+        self.assertEqual(obs, 'K')
+
+        obs = _get_machine_code('D00611')
+        self.assertEqual(obs, 'D')
+
+        obs = _get_machine_code('MN01225')
+        self.assertEqual(obs, 'MN')
+
+    def test__get_machine_code_err(self):
+        with self.assertRaisesRegex(ValueError,
+                                    'Cannot find a machine code. This '
+                                    'instrument model is malformed 8675309. '
+                                    'The machine code is a one or two '
+                                    'character prefix.'):
+            _get_machine_code('8675309')
+
+    def test_get_model_and_center_by_model_prefix(self):
+        obs = get_model_and_center('D32611_0365_G00DHB5YXX')
+        self.assertEqual(obs, ('Illumina HiSeq 2500', 'UCSDMI'))
+
+        obs = get_model_and_center('A86753_0365_G00DHB5YXX')
+        self.assertEqual(obs, ('Illumina NovaSeq 6000', 'UCSDMI'))
+
+    def test_get_model_and_center_by_instrument_id(self):
+        obs = get_model_and_center('A00953_0032_AHWMGJDDXX')
+        self.assertEqual(obs, ('Illumina NovaSeq 6000', 'IGM'))
+
+        obs = get_model_and_center('A00169_8131_AHKXYNDHXX')
+        self.assertEqual(obs, ('Illumina NovaSeq 6000', 'LJI'))
+
+        obs = get_model_and_center('M05314_0255_000000000-J46T9')
+        self.assertEqual(obs, ('Illumina MiSeq', 'KLM'))
+
+        obs = get_model_and_center('K00180_0957_AHCYKKBBXY')
+        self.assertEqual(obs, ('Illumina HiSeq 4000', 'IGM'))
+
+        obs = get_model_and_center('D00611_0712_BH37W2BCX3_RKL0040')
+        self.assertEqual(obs, ('Illumina HiSeq 2500', 'IGM'))
+
+        obs = get_model_and_center('MN01225_0002_A000H2W3FY')
+        self.assertEqual(obs, ('Illumina MiniSeq', 'CMI'))
+
+    def test_get_model_and_center_by_model_prefix_err_no_match(self):
+        err = ""
+        with self.assertRaisesRegex(ValueError, err):
+            get_model_and_center('MQ01225_0002_A000H2W3FY')
+
+    def test_get_sequencers_w_key_value(self):
+        """Test get sequencers with given key-value pair in default config."""
+        obs = get_sequencers_w_key_value(
+            'model_name', 'Illumina MiniSeq')
+        self.assertEqual(len(obs), 1)
+        self.assertEqual(obs["MiniSeq"]['machine_prefix'], 'MN')
+
+    def test_get_sequencers_w_key_value_none(self):
+        """Test no sequencers with given key-value pair in default config."""
+        obs = get_sequencers_w_key_value(
+            'model_name', 'Illumina YourSeq')
+        self.assertEqual(len(obs), 0)
+
+    def test_get_sequencers_w_key_value_w_external_mapping(self):
+        """Test get sequencers with given key-value pair in external dict."""
+        external_mapping = MappingProxyType({
+            "MiniSeq": {
+                'machine_prefix': 'MN',
+                'model_name': 'Illumina MiniSeq',
+                'revcomp_samplesheet_i5_index': False
+            },
+            "NovaSeq6000": {
+                'machine_prefix': 'A',
+                'model_name': 'Illumina NovaSeq 6000',
+                'revcomp_samplesheet_i5_index': True
+            },
+            "HiSeq2500": {
+                'machine_prefix': 'D',
+                'model_name': 'Illumina HiSeq 2500',
+                'revcomp_samplesheet_i5_index': False
+            }
+        })
+
+        obs = get_sequencers_w_key_value(
+            'revcomp_samplesheet_i5_index', False, existing_types=external_mapping)
+        self.assertEqual(len(obs), 2)
+        self.assertIn('HiSeq2500', obs)
+        self.assertIn('MiniSeq', obs)
+
+    def test_get_sequencers_w_key_value_err_malformed_mapping(self):
+        """Test error getting sequencers w key-value pair in bad dict."""
+        external_mapping = MappingProxyType({
+            "MiniSeq": {
+                'machine_prefix': 'MN',
+                'model_name': 'Illumina MiniSeq',
+                'revcomp_samplesheet_i5_index': False
+            },
+            "NovaSeq6000": {
+                'machine_prefix': 'A',
+                'model_name': 'Illumina NovaSeq 6000',
+                'revcomp_samplesheet_i5_index': True
+            },
+            "HiSeq2500": "red"
+        })
+
+        err = "Info for sequencer type 'HiSeq2500' is not a dictionary."
+        with self.assertRaisesRegex(ValueError, err):
+            get_sequencers_w_key_value(
+                'machine_prefix', 'A', existing_types=external_mapping)
+
+    def test_get_sequencers_w_key_value_not_a_mapping(self):
+        """Test error getting sequencers w key-value pair in bad dict."""
+        err = "existing_types must be a MappingProxyType or None."
+        with self.assertRaisesRegex(ValueError, err):
+            get_sequencers_w_key_value(
+                'machine_prefix', 'A', existing_types='red')
+
+    def test_get_i5_index_sequencers(self):
+        external_mapping = MappingProxyType({
+            "MiniSeq": {
+                'machine_prefix': 'MN',
+                'model_name': 'Illumina MiniSeq',
+                'revcomp_samplesheet_i5_index': False
+            },
+            "NovaSeq6000": {
+                'machine_prefix': 'A',
+                'model_name': 'Illumina NovaSeq 6000',
+                'revcomp_samplesheet_i5_index': True
+            },
+            "HiSeq2500": {
+                # NB: has no revcomp_samplesheet_i5_index key so not returned
+                'machine_prefix': 'D',
+                'model_name': 'Illumina HiSeq 2500'
+            }
+        })
+
+        obs = get_i5_index_sequencers(existing_types=external_mapping)
+        self.assertEqual(len(obs), 2)
+        self.assertIn('NovaSeq6000', obs)
+        self.assertIn('MiniSeq', obs)
+
+    def test_get_sequencer_type(self):
+        external_mapping = MappingProxyType({
+            "MiniSeq": {
+                'machine_prefix': 'MN',
+                'model_name': 'Illumina MiniSeq',
+                'revcomp_samplesheet_i5_index': False
+            },
+            "NovaSeq6000": {
+                'machine_prefix': 'A',
+                'model_name': 'Illumina NovaSeq 6000',
+                'revcomp_samplesheet_i5_index': True
+            },
+            "HiSeq2500": {
+                'machine_prefix': 'D',
+                'model_name': 'Illumina HiSeq 2500',
+                'revcomp_samplesheet_i5_index': False
+            }
+        })
+
+        obs = get_sequencer_type('NovaSeq6000', existing_types=external_mapping)
+        self.assertEqual(len(obs), 3)
+        self.assertEqual(obs['machine_prefix'], 'A')
+        self.assertEqual(obs['model_name'], 'Illumina NovaSeq 6000')
+        self.assertEqual(obs['revcomp_samplesheet_i5_index'], True)
+
+    def test_get_sequencer_type_err_not_found(self):
+        err = "Sequencer type 'YourSeq' not found."
+        with self.assertRaisesRegex(ValueError, err):
+            get_sequencer_type('YourSeq')
+
+    def test_is_i5_revcomp_sequencer_true(self):
+        obs = is_i5_revcomp_sequencer('HiSeq3000')
+        self.assertTrue(obs)
+
+    def test_is_i5_revcomp_sequencer_false(self):
+        obs = is_i5_revcomp_sequencer('HiSeq1500')
+        self.assertFalse(obs)
+
+    def test_is_i5_revcomp_sequencer_err_not_found(self):
+        external_mapping = MappingProxyType({
+            "MiniSeq": {
+                'machine_prefix': 'MN',
+                'model_name': 'Illumina MiniSeq',
+                'revcomp_samplesheet_i5_index': False
+            },
+            "NovaSeq6000": {
+                # NB: no revcomp_samplesheet_i5_index key so not found
+                'machine_prefix': 'A',
+                'model_name': 'Illumina NovaSeq 6000'
+            }
+        })
+
+        err = ("Sequencer type 'NovaSeq6000' does not have a "
+               "'revcomp_samplesheet_i5_index' key in sequencer types.")
+        with self.assertRaisesRegex(ValueError, err):
+            is_i5_revcomp_sequencer('NovaSeq6000',
+                                    existing_types=external_mapping)
+
+
+if __name__ == "__main__":
+    main()

--- a/metapool/tests/test_sequencers.py
+++ b/metapool/tests/test_sequencers.py
@@ -1,6 +1,6 @@
-from metapool.sequencers import _get_machine_code, get_model_and_center, \
-    get_sequencers_w_key_value, get_i5_index_sequencers, get_sequencer_type, \
-    is_i5_revcomp_sequencer
+from metapool.sequencers import _deep_freeze, _get_machine_code, \
+    get_model_and_center, get_sequencers_w_key_value, get_sequencer_type, \
+    get_i5_index_sequencers, is_i5_revcomp_sequencer
 from types import MappingProxyType
 from unittest import TestCase, main
 
@@ -69,8 +69,8 @@ class TestSequencers(TestCase):
         self.assertEqual(len(obs), 0)
 
     def test_get_sequencers_w_key_value_w_external_mapping(self):
-        """Test get sequencers with given key-value pair in external dict."""
-        external_mapping = MappingProxyType({
+        """Test get sequencers with given key-value pair in external map."""
+        external_mapping = _deep_freeze({
             "MiniSeq": {
                 'machine_prefix': 'MN',
                 'model_name': 'Illumina MiniSeq',
@@ -95,35 +95,35 @@ class TestSequencers(TestCase):
         self.assertIn('MiniSeq', obs)
 
     def test_get_sequencers_w_key_value_err_malformed_mapping(self):
-        """Test error getting sequencers w key-value pair in bad dict."""
+        """Test error getting sequencers w key-value pair in bad mapping."""
         external_mapping = MappingProxyType({
-            "MiniSeq": {
+            "MiniSeq": _deep_freeze({
                 'machine_prefix': 'MN',
                 'model_name': 'Illumina MiniSeq',
                 'revcomp_samplesheet_i5_index': False
-            },
-            "NovaSeq6000": {
+            }),
+            "NovaSeq6000": _deep_freeze({
                 'machine_prefix': 'A',
                 'model_name': 'Illumina NovaSeq 6000',
                 'revcomp_samplesheet_i5_index': True
-            },
+            }),
             "HiSeq2500": "red"
         })
 
-        err = "Info for sequencer type 'HiSeq2500' is not a dictionary."
+        err = "Info for sequencer type 'HiSeq2500' is not a MappingProxyType."
         with self.assertRaisesRegex(ValueError, err):
             get_sequencers_w_key_value(
                 'machine_prefix', 'A', existing_types=external_mapping)
 
     def test_get_sequencers_w_key_value_not_a_mapping(self):
-        """Test error getting sequencers w key-value pair in bad dict."""
+        """Test error getting sequencers w key-value pair from bad input."""
         err = "existing_types must be a MappingProxyType or None."
         with self.assertRaisesRegex(ValueError, err):
             get_sequencers_w_key_value(
                 'machine_prefix', 'A', existing_types='red')
 
     def test_get_i5_index_sequencers(self):
-        external_mapping = MappingProxyType({
+        external_mapping = _deep_freeze({
             "MiniSeq": {
                 'machine_prefix': 'MN',
                 'model_name': 'Illumina MiniSeq',
@@ -172,19 +172,23 @@ class TestSequencers(TestCase):
         self.assertEqual(obs['revcomp_samplesheet_i5_index'], True)
 
     def test_get_sequencer_type_err_not_found(self):
+        """Test error when sequencer type not found."""
         err = "Sequencer type 'YourSeq' not found."
         with self.assertRaisesRegex(ValueError, err):
             get_sequencer_type('YourSeq')
 
     def test_is_i5_revcomp_sequencer_true(self):
+        """Test result for sequencer that does revcomp i5."""
         obs = is_i5_revcomp_sequencer('HiSeq3000')
         self.assertTrue(obs)
 
     def test_is_i5_revcomp_sequencer_false(self):
+        """Test result for sequencer that does not revcomp i5."""
         obs = is_i5_revcomp_sequencer('HiSeq1500')
         self.assertFalse(obs)
 
     def test_is_i5_revcomp_sequencer_err_not_found(self):
+        """Test error when sequencer doesn't have i5 revcomp info."""
         external_mapping = MappingProxyType({
             "MiniSeq": {
                 'machine_prefix': 'MN',

--- a/notebooks/matrix_tube_pipeline_seqcount_norm.ipynb
+++ b/notebooks/matrix_tube_pipeline_seqcount_norm.ipynb
@@ -21,6 +21,7 @@
     "from metapool.mp_strings import PM_SAMPLE_KEY, PM_WELL_KEY, PM_LIB_WELL_KEY\n",
     "from metapool.sample_sheet import (\n",
     "    STANDARD_METAG_SHEET_TYPE, ABSQUANT_SHEET_TYPE, make_sections_dict)\n",
+    "from metapool.sequencers import get_i5_index_sequencers\n",
     "%watermark -i -v -iv -m -h -p metapool,sample_sheet,openpyxl -u"
    ],
    "outputs": [],
@@ -1656,9 +1657,7 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": [
-    "[x for x in REVCOMP_SEQUENCERS + OTHER_SEQUENCERS if x.lower().startswith(\"novaseq\")]"
-   ],
+   "source": "[x for x in get_i5_index_sequencers() if x.lower().startswith(\"novaseq\")]",
    "outputs": [],
    "execution_count": null
   },

--- a/sequencer_types.yml
+++ b/sequencer_types.yml
@@ -1,0 +1,68 @@
+# NB: any sampler without a revcomp_samplesheet_i5_index key will not be
+# available to users when making sample sheets, because we don't know what that
+# value should be, and it's better to error than to silently do the wrong thing
+HiSeq1500:
+    model_name: 'Illumina HiSeq 1500'
+    revcomp_samplesheet_i5_index: false
+HiSeq2500:
+    model_name: 'Illumina HiSeq 2500'
+    revcomp_samplesheet_i5_index: false
+    machine_prefix: 'D'
+HiSeq3000:
+    model_name: 'Illumina HiSeq 3000'
+    revcomp_samplesheet_i5_index: true
+HiSeq4000:
+    model_name: 'Illumina HiSeq 4000'
+    revcomp_samplesheet_i5_index: true
+    machine_prefix: 'K'
+iSeq:
+    model_name: 'Illumina iSeq'
+    revcomp_samplesheet_i5_index: true
+    machine_prefix: 'FS'
+    delete_settings:
+        - "MaskShortReads"
+        - "OverrideCycles"
+MiniSeq:
+    model_name: 'Illumina MiniSeq'
+    # Per the Illumina Knowledge Base's “Guidelines for reverse complementing
+    # i5 sequences for demultiplexing”,
+    # https://knowledge.illumina.com/software/general/software-general-reference_material-list/000001800
+    # MiniSeq Rapid Kit always use forward orientation, so if we were to use
+    # those, we would need to modify this value.
+    revcomp_samplesheet_i5_index: true
+    machine_prefix: 'MN'
+MiSeq:
+    model_name: 'Illumina MiSeq'
+    revcomp_samplesheet_i5_index: false
+    machine_prefix: 'M'
+MiSeqi100:
+    model_name: 'Illumina MiSeq i100'
+    machine_prefix: 'SH'
+    # Per the Illumina Knowledge Base's “Guidelines for reverse complementing
+    # i5 sequences for demultiplexing”,
+    # https://knowledge.illumina.com/software/general/software-general-reference_material-list/000001800
+    # no revcomping of i5 index sequences is required for MiSeq i100 *IF* we
+    # are using standalone BCL convert.  If we ever change how we are doing
+    # FASTQ generation, we may need to change this.
+NextSeq:
+    model_name: 'Illumina NextSeq 500/550'
+    revcomp_samplesheet_i5_index: true
+NovaSeq6000:
+    model_name: 'Illumina NovaSeq 6000'
+    revcomp_samplesheet_i5_index: true
+    machine_prefix: 'A'
+NovaSeqX:
+    model_name: 'Illumina NovaSeq X'
+    # Per the Illumina Knowledge Base's “Guidelines for reverse complementing
+    # i5 sequences for demultiplexing",
+    # https://knowledge.illumina.com/software/general/software-general-reference_material-list/000001800
+    # NovaSeqX/XPlus do not require reverse complementing of i5 index sequences
+    # *for standalone BCL convert*.  They *do* require it for standalone
+    # bcl2fastq or BSSH FASTQ generation, so if we ever change how we are doing
+    # FASTQ generation, we may need to change this.
+    revcomp_samplesheet_i5_index: false
+    machine_prefix: 'LH'
+NovaSeqXPlus:
+    model_name: 'Illumina NovaSeq X Plus'
+    # See above comment for NovaSeqX re: revcomp_samplesheet_i5_index
+    revcomp_samplesheet_i5_index: false


### PR DESCRIPTION
Fix #234 

This pulls data structures and functions out of prep.py and moves them into a config file and a new sequencers.py module (and does the same with test_prep.py and the new test_sequencers.py), and adds a few new methods in sequencers.py to shield code that uses this module from the details of the implementation.  Relatively minimal changes to metapool.py, samplesheet.py, and the matrix tube notebook to use these methods in sequencers.py instead of multiple separate lists.