### PR TITLE
ensure deployment and config files are installed with kl-metapool

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
 include versioneer.py
 include metapool/_version.py
-graft notebooks
+include deploy.sh
+include environment.yml
+include sequencer_types.yml
+# graft notebooks

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(name='metapool',
       packages=find_packages(),
       package_data={
           'metapool': ['data/*.tsv', 'data/*.xlsx', 'tests/data/*.csv']},
+      include_package_data=True,
       # adding all the notebooks fps
       data_files=notebooks_fp,
       install_requires=base,


### PR DESCRIPTION
I see that `qp-klp` is throwing errors trying to use functions from `sequencers.py` because it can't find the `sequencer_types.yml` file.  I can't be sure, but I suspect this may mean it is not being deployed.

AFAICT, `kl-metapool` has a `manifest.ini` file but that file isn't used since `include_package_data=True` isn't set in `setup.py` (?)  I have therefore added `include_package_data=True` to`setup.py` and added the ``environment.yml`, `deploy.sh`, and `sequencer_types.yml` files to `manifest.ini`.  I commented out `graft notebooks` because it seems to me to potentially conflict with the way notebooks are currently added in the `setup.py` using the `data_files` value.