### PR TITLE
Add support for parsing revio run ids and getting prep file platform and sequencing method from sequencer type

### DIFF
--- a/metapool/config/sequencer_types.yml
+++ b/metapool/config/sequencer_types.yml
@@ -110,5 +110,4 @@ Revio:
     # NB: *no* revcomp_samplesheet_i5_index entry because that isn't
     # relevant to this technology
     platform: "PacBio"
-    # TODO: get appropriate sequencing method text
-    sequencing_method: "TODO: get from Gail?"
+    sequencing_method: "single molecule real-time (SMRT) long read sequencing"

--- a/metapool/config/sequencer_types.yml
+++ b/metapool/config/sequencer_types.yml
@@ -4,19 +4,27 @@
 HiSeq1500:
     model_name: 'Illumina HiSeq 1500'
     revcomp_samplesheet_i5_index: false
+    platform: "Illumina"
+    sequencing_method: "sequencing by synthesis"
 HiSeq2500:
     model_name: 'Illumina HiSeq 2500'
     revcomp_samplesheet_i5_index: false
     machine_prefix: 'D'
     profile_name: 'HiSeq 2500'
+    platform: "Illumina"
+    sequencing_method: "sequencing by synthesis"
 HiSeq3000:
     model_name: 'Illumina HiSeq 3000'
     revcomp_samplesheet_i5_index: true
+    platform: "Illumina"
+    sequencing_method: "sequencing by synthesis"
 HiSeq4000:
     model_name: 'Illumina HiSeq 4000'
     revcomp_samplesheet_i5_index: true
     machine_prefix: 'K'
     profile_name: 'HiSeq 4000'
+    platform: "Illumina"
+    sequencing_method: "sequencing by synthesis"
 iSeq:
     model_name: 'Illumina iSeq'
     revcomp_samplesheet_i5_index: true
@@ -25,6 +33,8 @@ iSeq:
         - "MaskShortReads"
         - "OverrideCycles"
     profile_name: 'iSeq'
+    platform: "Illumina"
+    sequencing_method: "sequencing by synthesis"
 MiniSeq:
     model_name: 'Illumina MiniSeq'
     # Per the Illumina Knowledge Base's “Guidelines for reverse complementing
@@ -35,11 +45,15 @@ MiniSeq:
     revcomp_samplesheet_i5_index: true
     machine_prefix: 'MN'
     profile_name: 'MiniSeq'
+    platform: "Illumina"
+    sequencing_method: "sequencing by synthesis"
 MiSeq:
     model_name: 'Illumina MiSeq'
     revcomp_samplesheet_i5_index: false
     machine_prefix: 'M'
     profile_name: 'MiSeq'
+    platform: "Illumina"
+    sequencing_method: "sequencing by synthesis"
 MiSeqi100:
     model_name: 'Illumina MiSeq i100'
     machine_prefix: 'SH'
@@ -50,14 +64,20 @@ MiSeqi100:
     # are using standalone BCL convert.  If we ever change how we are doing
     # FASTQ generation, we may need to change this.
     profile_name: 'MiSeq i100'
+    platform: "Illumina"
+    sequencing_method: "sequencing by synthesis"
 NextSeq:
     model_name: 'Illumina NextSeq 500/550'
     revcomp_samplesheet_i5_index: true
+    platform: "Illumina"
+    sequencing_method: "sequencing by synthesis"
 NovaSeq6000:
     model_name: 'Illumina NovaSeq 6000'
     revcomp_samplesheet_i5_index: true
     machine_prefix: 'A'
     profile_name: 'NovaSeq 6000'
+    platform: "Illumina"
+    sequencing_method: "sequencing by synthesis"
 NovaSeqX:
     model_name: 'Illumina NovaSeq X'
     # Per the Illumina Knowledge Base's “Guidelines for reverse complementing
@@ -70,10 +90,14 @@ NovaSeqX:
     revcomp_samplesheet_i5_index: false
     machine_prefix: 'LH'
     profile_name: 'NovaSeq X'
+    platform: "Illumina"
+    sequencing_method: "sequencing by synthesis"
 NovaSeqXPlus:
     model_name: 'Illumina NovaSeq X Plus'
     # See above comment for NovaSeqX re: revcomp_samplesheet_i5_index
     revcomp_samplesheet_i5_index: false
+    platform: "Illumina"
+    sequencing_method: "sequencing by synthesis"
 # NB: InstrumentUtils class in qp-klp used to define
 # an 'SN': 'RapidRun' machine prefix, but as of 20250703,
 # we don't seem to have any data with that prefix.  The
@@ -85,3 +109,6 @@ Revio:
     profile_name: 'Revio'
     # NB: *no* revcomp_samplesheet_i5_index entry because that isn't
     # relevant to this technology
+    platform: "PacBio"
+    # TODO: get appropriate sequencing method text
+    sequencing_method: "TODO: get from Gail?"

--- a/metapool/prep.py
+++ b/metapool/prep.py
@@ -4,7 +4,10 @@ from glob import glob
 from metapool.mp_strings import get_short_name_and_id, \
     PM_WELL_ID_384_KEY
 from metapool.plate import PlateReplication
-from metapool.sequencers import get_model_and_center
+from metapool.sequencers import\
+     get_sequencer_type_name_and_run_center_by_instrument_code, \
+     get_key_value_by_sequencer_type_name, MODEL_NAME_KEY, PLATFORM_KEY, \
+     SEQUENCING_METH_KEY
 from os import sep, listdir
 from os.path import (basename, isdir, join, split, abspath, exists,
                      normpath)
@@ -61,21 +64,24 @@ AMPLICON_PREP_COLUMN_RENAMER = {
     'sample sheet Sample_ID': 'well_description'
 }
 
+_LAB_RUN_CENTER = "UCSDMI"
 
-def parse_illumina_run_id(run_id):
-    """Parse a run identifier
+
+def parse_run_id(run_id):
+    """Parse a run identifier to get run date and instrument code
 
     Parameters
     ----------
     run_id: str
-        The name of a run
+        The name of a run, such as '161004_D00611_0365_AH2HJ5BCXY',
+        '20220303_FS10001773_6_BRB11606-1914' or 'r84137_20250428_213201'
 
     Returns
     -------
     str:
         When the run happened (YYYY-MM-DD)
     str:
-        Instrument code
+        Instrument code, like 'D00611_0365_AH2HJ5BCXY' or 'r84137'
     """
 
     # Format should be YYMMDD_machinename_XXXX_FC
@@ -90,31 +96,38 @@ def parse_illumina_run_id(run_id):
     # the trailing -XXXX piece
     matches8 = re.search(r'^(\d{8})_([\w-]*)', run_id)
 
-    if matches6 is None and matches8 is None:
-        raise ValueError('Unrecognized run identifier format "%s". The '
-                         'expected format is either '
-                         'YYMMDD_machinename_XXXX_FC or '
-                         'YYYYMMDD_machinename_XXXX-XXXX' %
-                         run_id)
+    matches_pacbio = re.search(r'^(r\d{5})_(\d{8})_\d{6}', run_id)
 
+    err_msg = 'Unrecognized run identifier format "%s". The ' \
+              'expected format is either ' \
+              'YYMMDD_machinename_XXXX_FC ,  ' \
+              'YYYYMMDD_machinename_XXXX-XXXX, or ' \
+              'rXXXXX_YYYYMMDD_XXXXXX' % run_id
+
+    if matches6 is None and matches8 is None and matches_pacbio is None:
+        raise ValueError(err_msg)
+
+    inst_code_index = 2
+    date_index = 1
     if matches6 is None:
-        matches = matches8
         fmt = "%Y%m%d"
+        if matches_pacbio is not None:
+            matches = matches_pacbio
+            inst_code_index = 1
+            date_index = 2
+        else:
+            matches = matches8
     else:
         matches = matches6
         fmt = "%y%m%d"
 
     if len(matches.groups()) != 2:
-        raise ValueError('Unrecognized run identifier format "%s". The '
-                         'expected format is either '
-                         'YYMMDD_machinename_XXXX_FC or '
-                         'YYYYMMDD_machinename_XXXX-XXXX' %
-                         run_id)
+        raise ValueError(err_msg)
 
-    # convert illumina's format to qiita's format
-    run_date = datetime.strptime(matches[1], fmt).strftime('%Y-%m-%d')
+    # convert run id's date format to qiita's format
+    run_date = datetime.strptime(matches[date_index], fmt).strftime('%Y-%m-%d')
 
-    return run_date, matches[2]
+    return run_date, matches[inst_code_index]
 
 
 def remove_qiita_id(project_name):
@@ -215,13 +228,14 @@ def _check_invalid_names(sample_names):
 
 
 def process_sample(sample, prep_columns, run_center, run_date, run_prefix,
-                   project_name, instrument_model, run_id, lane):
+                   project_name, instrument_model, run_id, lane, platform, 
+                   sequencing_method):
     # initialize result
     result = {c: '' for c in prep_columns}
 
     # hard-coded columns
-    result["platform"] = "Illumina"
-    result["sequencing_meth"] = "sequencing by synthesis"
+    result["platform"] = platform
+    result["sequencing_meth"] = sequencing_method
     result["center_name"] = "UCSD"
 
     # manually generated columns
@@ -302,8 +316,19 @@ def preparations_for_run(run_path, sheet_data_df, generated_prep_columns,
         not be mapped to a file. it is similarly organized.
     """
     _, run_id = split(normpath(run_path))
-    run_date, instrument_code = parse_illumina_run_id(run_id)
-    instrument_model, run_center = get_model_and_center(instrument_code)
+    run_date, instrument_code = parse_run_id(run_id)
+    sequencer_type_name, run_center = \
+        get_sequencer_type_name_and_run_center_by_instrument_code(
+            instrument_code)
+    if run_center is None: # use default
+        run_center = _LAB_RUN_CENTER
+
+    instrument_model = get_key_value_by_sequencer_type_name(
+        MODEL_NAME_KEY, sequencer_type_name)
+    platform = get_key_value_by_sequencer_type_name(
+        PLATFORM_KEY, sequencer_type_name)
+    sequencing_method = get_key_value_by_sequencer_type_name(
+        SEQUENCING_METH_KEY, sequencer_type_name)
 
     # NB: For now it is safe to use the working directory as the search
     # root, but in the future it would be better to give the path to the
@@ -414,7 +439,8 @@ def preparations_for_run(run_path, sheet_data_df, generated_prep_columns,
                     data.append(process_sample(sample, all_columns,
                                                run_center, run_date,
                                                run_prefix, project_name,
-                                               instrument_model, run_id, lane))
+                                               instrument_model, run_id, lane,
+                                               platform, sequencing_method))
 
             if not data:
                 warnings.warn('Project %s and Lane %s have no data' %

--- a/metapool/prep.py
+++ b/metapool/prep.py
@@ -228,7 +228,7 @@ def _check_invalid_names(sample_names):
 
 
 def process_sample(sample, prep_columns, run_center, run_date, run_prefix,
-                   project_name, instrument_model, run_id, lane, platform, 
+                   project_name, instrument_model, run_id, lane, platform,
                    sequencing_method):
     # initialize result
     result = {c: '' for c in prep_columns}
@@ -320,7 +320,7 @@ def preparations_for_run(run_path, sheet_data_df, generated_prep_columns,
     sequencer_type_name, run_center = \
         get_sequencer_type_name_and_run_center_by_instrument_code(
             instrument_code)
-    if run_center is None: # use default
+    if run_center is None:  # use default
         run_center = _LAB_RUN_CENTER
 
     instrument_model = get_key_value_by_sequencer_type_name(

--- a/metapool/sequencers.py
+++ b/metapool/sequencers.py
@@ -124,7 +124,7 @@ def _load_sequencer_types(existing_types=None, test_only_fp=None):
 
 
 def _get_machine_prefix(instrument_model):
-    """Get the machine code for an instrument's model string
+    """Get the machine prefix for an instrument's model string
 
     Parameters
     ----------
@@ -134,16 +134,16 @@ def _get_machine_prefix(instrument_model):
     Returns
     -------
     str
-        The machine code, which is the first 1 or 2 letters of the instrument
+        The machine prefix, which is the first 1 or 2 letters of the instrument
         model.
 
     Raises
     ------
     ValueError
         If the instrument model is malformed and does not contain a valid
-        machine code.
+        machine prefix.
     """
-    # the machine code is everything before the first number
+    # the machine prefix is everything before the first number
     # (we expect these to be letters, so pattern could be improved ...)
     matches = re.match(r"^(.*?)\d.*", instrument_model)
 
@@ -152,7 +152,7 @@ def _get_machine_prefix(instrument_model):
         if machine_code != "":
             return machine_code
 
-    raise ValueError(f"Cannot find a machine code; the instrument "
+    raise ValueError(f"Cannot find a machine prefix; the instrument "
                      f"model '{instrument_model}' is malformed.")
 
 

--- a/metapool/sequencers.py
+++ b/metapool/sequencers.py
@@ -122,7 +122,7 @@ def _load_sequencer_types(existing_types=None, test_only_fp=None):
     return immutable_sequencer_types
 
 
-def _get_machine_code(instrument_model):
+def _get_machine_prefix(instrument_model):
     """Get the machine code for an instrument's model string
 
     Parameters
@@ -155,50 +155,112 @@ def _get_machine_code(instrument_model):
                      f"model '{instrument_model}' is malformed.")
 
 
-def _get_model_by_machine_prefix(
-        instrument_prefix, sequencer_types=None, model_key=_MODEL_NAME_KEY):
-    """Get the instrument model by its machine prefix.
+def _get_sequencer_type_name_by_machine_prefix(
+        machine_prefix, sequencer_types=None):
+    """Get the sequencer type name associated with input machine prefix.
 
     Parameters
     ----------
-    instrument_prefix: str
+    machine_prefix: str
         The machine prefix of the instrument, e.g., 'MN' for MN01225.
     sequencer_types: MappingProxyType, optional
         A mapping of available sequencer types. If None, the
         sequencer types will be loaded from the YAML file.
-    model_key: str, optional
-        The key in which to look for the model name to return from the
+
+    Returns
+    -------
+    str
+        The model type associated with the sequencer type that matches
+        the given machine prefix.
+
+    Raises
+    ------
+    ValueError
+        If the machine prefix is not recognized or if multiple
+        sequencer types match the given prefix.
+    """
+    models_w_prefix = get_sequencers_w_key_value(
+        _MACHINE_PREFIX_KEY, machine_prefix,
+        existing_types=sequencer_types)
+    if len(models_w_prefix) == 0:
+        raise ValueError(
+            f"Unrecognized {_MACHINE_PREFIX_KEY} '{machine_prefix}'.")
+    elif len(models_w_prefix) > 1:
+        raise ValueError(
+            f"Found {len(models_w_prefix)} sequencer types with "
+            f"{_MACHINE_PREFIX_KEY} '{machine_prefix}': "
+            f"{', '.join(models_w_prefix)}.")
+    # end if got an unexpected number of sequencer types w given prefix
+
+    # get the only key (see above :) in the mapping proxy
+    sequencer_type_name = next(iter(models_w_prefix))
+    return sequencer_type_name
+
+
+def _get_key_value_by_sequencer_type_name(
+        sequencer_type_name, sequencer_types, input_key=_MODEL_NAME_KEY):
+    """Get the value associated with the input key by its sequencer type name.
+
+    Parameters
+    ----------
+    sequencer_type_name: str
+        The sequencer type name, e.g., 'iSeq', 'NovaSeq6000', etc.
+    sequencer_types: MappingProxyType
+        A mapping of available sequencer types.
+    input_key: str, optional
+        The key in which to look for value to return from the
         sequencer types. Defaults to _MODEL_NAME_KEY.
 
     Returns
     -------
     object
-        The value of the model key in the sequencer type that matches
-        the given instrument prefix. Will be an immutable type.
+        The value associated with the input key in the sequencer type that
+        matches the given sequencer type. Will be an immutable type.
 
     Raises
     ------
     ValueError
-        If the instrument prefix is not recognized or if multiple
+        If the sequencer type name is not recognized or if it does not
+        contain a key with the name in input_key.
+    """
+    
+    inst_sequencer_type = sequencer_types[sequencer_type_name]
+    found_key_value = inst_sequencer_type[input_key]
+    return found_key_value
+
+
+def get_key_value_by_machine_prefix(
+        machine_prefix, sequencer_types=None, input_key=_MODEL_NAME_KEY):
+    """Get value of input key for sequencer type with input machine prefix.
+
+    Parameters
+    ----------
+    machine_prefix: str
+        The prefix of the instrument, e.g., 'MN' for MN01225.
+    sequencer_types: MappingProxyType, optional
+        A mapping of available sequencer types. If None, the
+        sequencer types will be loaded from the YAML file.
+    input_key: str, optional
+        The key in which to look for the value to return from the
+        sequencer types. Defaults to _MODEL_NAME_KEY.
+
+    Returns
+    -------
+    object
+        The value associated with the key in the sequencer type that matches
+        the given machine prefix. Will be an immutable type.
+
+    Raises
+    ------
+    ValueError
+        If the machine prefix is not recognized or if multiple
         sequencer types match the given prefix.
     """
-    models_w_prefix = get_sequencers_w_key_value(
-        _MACHINE_PREFIX_KEY, instrument_prefix,
-        existing_types=sequencer_types)
-    if len(models_w_prefix) == 0:
-        raise ValueError(
-            f"Unrecognized {_MACHINE_PREFIX_KEY} '{instrument_prefix}'.")
-    elif len(models_w_prefix) > 1:
-        raise ValueError(
-            f"Found {len(models_w_prefix)} sequencer types with "
-            f"{_MACHINE_PREFIX_KEY} '{instrument_prefix}': "
-            f"{', '.join(models_w_prefix)}.")
-    # end if got an unexpected number of sequencer types w given prefix
 
-    inst_model_type = next(iter(models_w_prefix))
-    instrument_model = _get_model_by_sequencer_type_name(
-        inst_model_type, sequencer_types=models_w_prefix,
-        model_key=model_key)
+    sequencer_type_name = _get_sequencer_type_name_by_machine_prefix(
+        machine_prefix, sequencer_types)
+    instrument_model = _get_key_value_by_sequencer_type_name(
+        sequencer_type_name, sequencer_types=sequencer_types, input_key=input_key)
     return instrument_model
 
 
@@ -231,27 +293,27 @@ def get_model_by_instrument_id(
     """
 
     sequencer_types = _load_sequencer_types(existing_types=sequencer_types)
-    instrument_prefix = _get_machine_code(instrument_id)
-    instrument_model = _get_model_by_machine_prefix(
-        instrument_prefix, sequencer_types=sequencer_types,
-        model_key=model_key)
+    machine_prefix = _get_machine_prefix(instrument_id)
+    instrument_model = get_key_value_by_machine_prefix(
+        machine_prefix, sequencer_types=sequencer_types,
+        input_key=model_key)
     return instrument_model
 
 
 def get_model_and_center(instrument_code):
-    """Determine instrument model and center using instrument code.
+    """Determine instrument model name and run center using instrument code.
 
     Parameters
     ----------
     instrument_code: str
-        Instrument code from a run identifier.
+        Instrument code from a run identifier, such as 'A00169_1234_AHJKLDSX2'.
 
     Returns
     -------
     str
-        Instrument model.
+        Instrument model name, such as 'Illumina NovaSeq 6000'.
     str
-        Run center associated with the instrument.
+        Run center associated with the instrument, such as 'UCSDMI'.
 
     Raises
     ------
@@ -266,47 +328,69 @@ def get_model_and_center(instrument_code):
     instrument_id = instrument_code.split('_')[0]
     if instrument_id in _INSTRUMENT_LOOKUP.index:
         run_center = _INSTRUMENT_LOOKUP.loc[instrument_id, _RUN_CENTER_KEY]
-        inst_model_type = _INSTRUMENT_LOOKUP.loc[
+        sequencer_type_name = _INSTRUMENT_LOOKUP.loc[
             instrument_id, _MODEL_TYPE_KEY]
-        instrument_model = _get_model_by_sequencer_type_name(
-            inst_model_type, sequencer_types=available_sequencer_types)
     else:
-        instrument_model = get_model_by_instrument_id(
-            instrument_id, sequencer_types=available_sequencer_types)
+        machine_prefix = _get_machine_prefix(instrument_id)
+        sequencer_type_name = _get_sequencer_type_name_by_machine_prefix(
+            machine_prefix, sequencer_types=available_sequencer_types)
     # end if instrument_id is in the lookup or if must look up by prefix
+
+    instrument_model = _get_key_value_by_sequencer_type_name(
+        sequencer_type_name, sequencer_types=available_sequencer_types)
 
     return instrument_model, run_center
 
 
-def _get_model_by_sequencer_type_name(
-        inst_model_type, sequencer_types, model_key=_MODEL_NAME_KEY):
-    """Get the instrument model by its sequencer type name.
+def get_key_values_and_run_center(instrument_code, input_keys_list):
+    """Get values for input keys and run center (if known) with instrument code
 
     Parameters
     ----------
-    inst_model_type: str
-        The sequencer type name, e.g., 'iSeq', 'NovaSeq6000', etc.
-    sequencer_types: MappingProxyType
-        A mapping of available sequencer types.
-    model_key: str, optional
-        The key in which to look for the model name to return from the
-        sequencer types. Defaults to _MODEL_NAME_KEY.
+    instrument_code: str
+        Instrument code from a run identifier, such as 'A00169_1234_AHJKLDSX2'.
 
     Returns
     -------
-    object
-        The value of the model key in the sequencer type that matches
-        the given sequencer type. Will be an immutable type.
+    dict
+        A mapping of input keys to their values for the sequencer type
+        associated with the instrument code.  For example:
+        { 'model_name': 'Illumina NovaSeq 6000', 'platform': 'Illumina' }
+        if the input_keys_list is ['model_name', 'platform'].
+    str
+        Run center explicitly associated with the instrument, such as 'LJI',
+        if it is known; otherwise, None.
 
     Raises
     ------
     ValueError
-        If the sequencer type name is not recognized or if it does not
-        contain a model name.
+        If zero or more than one machine prefixes are associated with
+        the instrument code.
     """
-    inst_sequencer_type = sequencer_types[inst_model_type]
-    instrument_model = inst_sequencer_type[model_key]
-    return instrument_model
+
+    run_center = None
+    available_sequencer_types = _load_sequencer_types()
+
+    instrument_id = instrument_code.split('_')[0]
+    if instrument_id in _INSTRUMENT_LOOKUP.index:
+        run_center = _INSTRUMENT_LOOKUP.loc[instrument_id, _RUN_CENTER_KEY]
+        sequencer_type_name = _INSTRUMENT_LOOKUP.loc[
+            instrument_id, _MODEL_TYPE_KEY]
+    else:
+        machine_prefix = _get_machine_prefix(instrument_id)
+        sequencer_type_name = _get_sequencer_type_name_by_machine_prefix(
+            machine_prefix, sequencer_types=available_sequencer_types)
+    # end if instrument_id is in the lookup or if must look up by prefix
+
+    key_values = {}
+    for curr_key in input_keys_list:
+        curr_value = _get_key_value_by_sequencer_type_name(
+            sequencer_type_name, sequencer_types=available_sequencer_types,
+            input_key=curr_key)
+        key_values[curr_key] = curr_value
+    # next key in input_keys_list
+
+    return key_values, run_center
 
 
 def get_sequencers_w_key_value(key, value, default=None, existing_types=None):

--- a/metapool/sequencers.py
+++ b/metapool/sequencers.py
@@ -198,8 +198,8 @@ def _get_sequencer_type_name_by_machine_prefix(
     return sequencer_type_name
 
 
-def get_key_value_by_sequencer_type_name(input_key,
-        sequencer_type_name, sequencer_types=None):
+def get_key_value_by_sequencer_type_name(
+        input_key, sequencer_type_name, sequencer_types=None):
     """Get the value associated with the input key by its sequencer type name.
 
     Parameters
@@ -307,7 +307,7 @@ def get_model_by_instrument_id(
 
 def get_sequencer_type_name_and_run_center_by_instrument_code(
         instrument_code, available_sequencer_types=None):
-    
+
     run_center = None
     available_sequencer_types = _load_sequencer_types(
         available_sequencer_types)

--- a/metapool/sequencers.py
+++ b/metapool/sequencers.py
@@ -6,14 +6,15 @@ import yaml
 
 DELETE_SETTINGS_KEY = "delete_settings"
 PROFILE_NAME_KEY = "profile_name"
+MODEL_NAME_KEY = 'model_name'
+PLATFORM_KEY = 'platform'
+SEQUENCING_METH_KEY = 'sequencing_method'
 
 _MACHINE_PREFIX_KEY = 'machine_prefix'
 _MODEL_TYPE_KEY = 'model'
-_MODEL_NAME_KEY = 'model_name'
 _RUN_CENTER_KEY = 'run_center'
 _REVCOMP_I5_KEY = "revcomp_samplesheet_i5_index"
 
-_LAB_RUN_CENTER = "UCSDMI"
 _SEQUENCER_TYPES_DIR = "config"
 _SEQUENCER_TYPES_YML_FNAME = 'sequencer_types.yml'
 
@@ -197,19 +198,21 @@ def _get_sequencer_type_name_by_machine_prefix(
     return sequencer_type_name
 
 
-def _get_key_value_by_sequencer_type_name(
-        sequencer_type_name, sequencer_types, input_key=_MODEL_NAME_KEY):
+def get_key_value_by_sequencer_type_name(input_key,
+        sequencer_type_name, sequencer_types=None):
     """Get the value associated with the input key by its sequencer type name.
 
     Parameters
     ----------
+    input_key: str
+        The key in which to look for value to return from the
+        sequencer types.
     sequencer_type_name: str
         The sequencer type name, e.g., 'iSeq', 'NovaSeq6000', etc.
-    sequencer_types: MappingProxyType
-        A mapping of available sequencer types.
-    input_key: str, optional
-        The key in which to look for value to return from the
-        sequencer types. Defaults to _MODEL_NAME_KEY.
+    sequencer_types: MappingProxyType, optional
+        A mapping of available sequencer types. If None, the
+        sequencer types will be loaded from the YAML file.
+
 
     Returns
     -------
@@ -223,14 +226,15 @@ def _get_key_value_by_sequencer_type_name(
         If the sequencer type name is not recognized or if it does not
         contain a key with the name in input_key.
     """
-    
+
+    sequencer_types = _load_sequencer_types(existing_types=sequencer_types)
     inst_sequencer_type = sequencer_types[sequencer_type_name]
     found_key_value = inst_sequencer_type[input_key]
     return found_key_value
 
 
 def get_key_value_by_machine_prefix(
-        machine_prefix, sequencer_types=None, input_key=_MODEL_NAME_KEY):
+        machine_prefix, sequencer_types=None, input_key=MODEL_NAME_KEY):
     """Get value of input key for sequencer type with input machine prefix.
 
     Parameters
@@ -242,7 +246,7 @@ def get_key_value_by_machine_prefix(
         sequencer types will be loaded from the YAML file.
     input_key: str, optional
         The key in which to look for the value to return from the
-        sequencer types. Defaults to _MODEL_NAME_KEY.
+        sequencer types. Defaults to MODEL_NAME_KEY.
 
     Returns
     -------
@@ -259,13 +263,14 @@ def get_key_value_by_machine_prefix(
 
     sequencer_type_name = _get_sequencer_type_name_by_machine_prefix(
         machine_prefix, sequencer_types)
-    instrument_model = _get_key_value_by_sequencer_type_name(
-        sequencer_type_name, sequencer_types=sequencer_types, input_key=input_key)
+    instrument_model = get_key_value_by_sequencer_type_name(
+        input_key, sequencer_type_name,
+        sequencer_types=sequencer_types)
     return instrument_model
 
 
 def get_model_by_instrument_id(
-        instrument_id, sequencer_types=None, model_key=_MODEL_NAME_KEY):
+        instrument_id, sequencer_types=None, model_key=MODEL_NAME_KEY):
     """Get the instrument model by its instrument ID.
 
     Parameters
@@ -300,76 +305,12 @@ def get_model_by_instrument_id(
     return instrument_model
 
 
-def get_model_and_center(instrument_code):
-    """Determine instrument model name and run center using instrument code.
-
-    Parameters
-    ----------
-    instrument_code: str
-        Instrument code from a run identifier, such as 'A00169_1234_AHJKLDSX2'.
-
-    Returns
-    -------
-    str
-        Instrument model name, such as 'Illumina NovaSeq 6000'.
-    str
-        Run center associated with the instrument, such as 'UCSDMI'.
-
-    Raises
-    ------
-    ValueError
-        If zero or more than one machine prefixes are associated with
-        the instrument code.
-    """
-
-    run_center = _LAB_RUN_CENTER  # Default run center for lab data
-    available_sequencer_types = _load_sequencer_types()
-
-    instrument_id = instrument_code.split('_')[0]
-    if instrument_id in _INSTRUMENT_LOOKUP.index:
-        run_center = _INSTRUMENT_LOOKUP.loc[instrument_id, _RUN_CENTER_KEY]
-        sequencer_type_name = _INSTRUMENT_LOOKUP.loc[
-            instrument_id, _MODEL_TYPE_KEY]
-    else:
-        machine_prefix = _get_machine_prefix(instrument_id)
-        sequencer_type_name = _get_sequencer_type_name_by_machine_prefix(
-            machine_prefix, sequencer_types=available_sequencer_types)
-    # end if instrument_id is in the lookup or if must look up by prefix
-
-    instrument_model = _get_key_value_by_sequencer_type_name(
-        sequencer_type_name, sequencer_types=available_sequencer_types)
-
-    return instrument_model, run_center
-
-
-def get_key_values_and_run_center(instrument_code, input_keys_list):
-    """Get values for input keys and run center (if known) with instrument code
-
-    Parameters
-    ----------
-    instrument_code: str
-        Instrument code from a run identifier, such as 'A00169_1234_AHJKLDSX2'.
-
-    Returns
-    -------
-    dict
-        A mapping of input keys to their values for the sequencer type
-        associated with the instrument code.  For example:
-        { 'model_name': 'Illumina NovaSeq 6000', 'platform': 'Illumina' }
-        if the input_keys_list is ['model_name', 'platform'].
-    str
-        Run center explicitly associated with the instrument, such as 'LJI',
-        if it is known; otherwise, None.
-
-    Raises
-    ------
-    ValueError
-        If zero or more than one machine prefixes are associated with
-        the instrument code.
-    """
-
+def get_sequencer_type_name_and_run_center_by_instrument_code(
+        instrument_code, available_sequencer_types=None):
+    
     run_center = None
-    available_sequencer_types = _load_sequencer_types()
+    available_sequencer_types = _load_sequencer_types(
+        available_sequencer_types)
 
     instrument_id = instrument_code.split('_')[0]
     if instrument_id in _INSTRUMENT_LOOKUP.index:
@@ -382,15 +323,7 @@ def get_key_values_and_run_center(instrument_code, input_keys_list):
             machine_prefix, sequencer_types=available_sequencer_types)
     # end if instrument_id is in the lookup or if must look up by prefix
 
-    key_values = {}
-    for curr_key in input_keys_list:
-        curr_value = _get_key_value_by_sequencer_type_name(
-            sequencer_type_name, sequencer_types=available_sequencer_types,
-            input_key=curr_key)
-        key_values[curr_key] = curr_value
-    # next key in input_keys_list
-
-    return key_values, run_center
+    return sequencer_type_name, run_center
 
 
 def get_sequencers_w_key_value(key, value, default=None, existing_types=None):

--- a/metapool/tests/test_prep.py
+++ b/metapool/tests/test_prep.py
@@ -9,7 +9,7 @@ from metapool.sample_sheet import (MetagenomicSampleSheetv90,
                                    sample_sheet_to_dataframe)
 from metapool.prep import (preparations_for_run, remove_qiita_id,
                            get_run_prefix,
-                           parse_illumina_run_id,
+                           parse_run_id,
                            _check_invalid_names, agp_transform, parse_prep,
                            generate_qiita_prep_file, qiita_scrub_name,
                            preparations_for_run_mapping_file, demux_pre_prep,
@@ -338,24 +338,28 @@ class TestPrep(TestCase):
         self.assertEqual(obs, 'project_')
 
     def test_parse_illumina_run_id(self):
-        date, rid = parse_illumina_run_id('161004_D00611_0365_AH2HJ5BCXY')
+        date, rid = parse_run_id('161004_D00611_0365_AH2HJ5BCXY')
         self.assertEqual(date, '2016-10-04')
         self.assertEqual(rid, 'D00611_0365_AH2HJ5BCXY')
 
-        date, rid = parse_illumina_run_id('160909_K00180_0244_BH7VNKBBXX')
+        date, rid = parse_run_id('160909_K00180_0244_BH7VNKBBXX')
         self.assertEqual(date, '2016-09-09')
         self.assertEqual(rid, 'K00180_0244_BH7VNKBBXX')
 
-        date, rid = parse_illumina_run_id('20220303_FS10001773_6_BRB11606-1914')  # noqa
+        date, rid = parse_run_id('20220303_FS10001773_6_BRB11606-1914')  # noqa
         self.assertEqual(date, '2022-03-03')
         self.assertEqual(rid, 'FS10001773_6_BRB11606-1914')
+
+        date, rid = parse_run_id('r84137_20250428_213201')
+        self.assertEqual(date, '2025-04-28')
+        self.assertEqual(rid, 'r84137')
 
     def test_parse_illumina_run_id_malformed(self):
         bad_entries = ['0220303_FS10001773_6_BRB11606-1914',
                        'verybad', '123456-bad', '12345678-bad']
         for bad in bad_entries:
             with self.assertRaises(ValueError):
-                parse_illumina_run_id(bad)
+                parse_run_id(bad)
 
     def test_agp_transform(self):
         columns = ['sample_name', 'experiment_design_description',

--- a/metapool/tests/test_sequencers.py
+++ b/metapool/tests/test_sequencers.py
@@ -1,4 +1,4 @@
-from metapool.sequencers import _deep_freeze, _get_machine_code, \
+from metapool.sequencers import _deep_freeze, _get_machine_prefix, \
     get_model_and_center, get_sequencers_w_key_value, get_sequencer_type, \
     get_i5_index_sequencers, is_i5_revcomp_sequencer, \
     get_model_by_instrument_id, PROFILE_NAME_KEY
@@ -8,20 +8,20 @@ from unittest import TestCase, main
 
 class TestSequencers(TestCase):
     def test__get_machine_code(self):
-        obs = _get_machine_code('K00180')
+        obs = _get_machine_prefix('K00180')
         self.assertEqual(obs, 'K')
 
-        obs = _get_machine_code('D00611')
+        obs = _get_machine_prefix('D00611')
         self.assertEqual(obs, 'D')
 
-        obs = _get_machine_code('MN01225')
+        obs = _get_machine_prefix('MN01225')
         self.assertEqual(obs, 'MN')
 
     def test__get_machine_code_err(self):
         err = ("Cannot find a machine code; the instrument model "
                "'8675309' is malformed.")
         with self.assertRaisesRegex(ValueError, err):
-            _get_machine_code('8675309')
+            _get_machine_prefix('8675309')
 
     def test_get_model_by_instrument_id(self):
         """Test getting model by machine prefix."""

--- a/metapool/tests/test_sequencers.py
+++ b/metapool/tests/test_sequencers.py
@@ -1,6 +1,8 @@
 from metapool.sequencers import _deep_freeze, _get_machine_prefix, \
-    get_model_and_center, get_sequencers_w_key_value, get_sequencer_type, \
+    get_sequencers_w_key_value, get_sequencer_type, \
     get_i5_index_sequencers, is_i5_revcomp_sequencer, \
+    get_sequencer_type_name_and_run_center_by_instrument_code, \
+    get_key_value_by_sequencer_type_name, \
     get_model_by_instrument_id, PROFILE_NAME_KEY
 from types import MappingProxyType
 from unittest import TestCase, main
@@ -62,36 +64,74 @@ class TestSequencers(TestCase):
             get_model_by_instrument_id(
                 'LH1118920', sequencer_types=external_mapping)
 
-    def test_get_model_and_center_by_model_prefix(self):
-        obs = get_model_and_center('D32611_0365_G00DHB5YXX')
-        self.assertEqual(obs, ('Illumina HiSeq 2500', 'UCSDMI'))
+    def test_get_sequencer_type_name_and_run_center_by_instrument_code_by_model_prefix(self):
+        obs = get_sequencer_type_name_and_run_center_by_instrument_code(
+            'D32611_0365_G00DHB5YXX')
+        self.assertEqual(obs, ('HiSeq2500', None))
 
-        obs = get_model_and_center('A86753_0365_G00DHB5YXX')
-        self.assertEqual(obs, ('Illumina NovaSeq 6000', 'UCSDMI'))
+        obs = get_sequencer_type_name_and_run_center_by_instrument_code(
+            'A86753_0365_G00DHB5YXX')
+        self.assertEqual(obs, ('NovaSeq6000', None))
 
-    def test_get_model_and_center_by_instrument_id(self):
-        obs = get_model_and_center('A00953_0032_AHWMGJDDXX')
-        self.assertEqual(obs, ('Illumina NovaSeq 6000', 'IGM'))
+    def test_get_sequencer_type_name_and_run_center_by_instrument_code_by_instrument_id(self):
+        obs = get_sequencer_type_name_and_run_center_by_instrument_code(
+            'A00953_0032_AHWMGJDDXX')
+        self.assertEqual(obs, ('NovaSeq6000', 'IGM'))
 
-        obs = get_model_and_center('A00169_8131_AHKXYNDHXX')
-        self.assertEqual(obs, ('Illumina NovaSeq 6000', 'LJI'))
+        obs = get_sequencer_type_name_and_run_center_by_instrument_code(
+            'A00169_8131_AHKXYNDHXX')
+        self.assertEqual(obs, ('NovaSeq6000', 'LJI'))
 
-        obs = get_model_and_center('M05314_0255_000000000-J46T9')
-        self.assertEqual(obs, ('Illumina MiSeq', 'KLM'))
+        obs = get_sequencer_type_name_and_run_center_by_instrument_code(
+            'M05314_0255_000000000-J46T9')
+        self.assertEqual(obs, ('MiSeq', 'KLM'))
 
-        obs = get_model_and_center('K00180_0957_AHCYKKBBXY')
-        self.assertEqual(obs, ('Illumina HiSeq 4000', 'IGM'))
+        obs = get_sequencer_type_name_and_run_center_by_instrument_code(
+            'K00180_0957_AHCYKKBBXY')
+        self.assertEqual(obs, ('HiSeq4000', 'IGM'))
 
-        obs = get_model_and_center('D00611_0712_BH37W2BCX3_RKL0040')
-        self.assertEqual(obs, ('Illumina HiSeq 2500', 'IGM'))
+        obs = get_sequencer_type_name_and_run_center_by_instrument_code(
+            'D00611_0712_BH37W2BCX3_RKL0040')
+        self.assertEqual(obs, ('HiSeq2500', 'IGM'))
 
-        obs = get_model_and_center('MN01225_0002_A000H2W3FY')
-        self.assertEqual(obs, ('Illumina MiniSeq', 'CMI'))
+        obs = get_sequencer_type_name_and_run_center_by_instrument_code(
+            'MN01225_0002_A000H2W3FY')
+        self.assertEqual(obs, ('MiniSeq', 'CMI'))
 
-    def test_get_model_and_center_by_model_prefix_err_no_match(self):
-        err = ""
+    def test_get_sequencer_type_name_and_run_center_by_instrument_code_by_model_prefix_err_no_match(self):
+        err = "Unrecognized machine_prefix 'MQ'."
         with self.assertRaisesRegex(ValueError, err):
-            get_model_and_center('MQ01225_0002_A000H2W3FY')
+            get_sequencer_type_name_and_run_center_by_instrument_code(
+                'MQ01225_0002_A000H2W3FY')
+
+    def test_get_key_value_by_sequencer_type_name(self):
+        """Test getting key value by sequencer type name."""
+        obs = get_key_value_by_sequencer_type_name(
+            'model_name', 'MiniSeq')
+        self.assertEqual(obs, 'Illumina MiniSeq')
+
+        obs = get_key_value_by_sequencer_type_name(
+            'platform', 'NovaSeq6000')
+        self.assertEqual(obs, 'Illumina')
+
+    def test_get_key_value_by_sequencer_type_name_input_dict(self):
+        """Test getting key value by sequencer type name from input dict."""
+        external_mapping = MappingProxyType({
+            "MiniSeq": {
+                'machine_prefix': 'MN',
+                'model_name': 'Illumina MiniMe',
+                'revcomp_samplesheet_i5_index': False
+            },
+            "HiSeq2500": {
+                'machine_prefix': 'D',
+                'model_name': 'Illumina HiSeq 2500',
+                'revcomp_samplesheet_i5_index': False
+            }
+        })
+
+        obs = get_key_value_by_sequencer_type_name(
+            'model_name', 'MiniSeq', sequencer_types=external_mapping)
+        self.assertEqual(obs, 'Illumina MiniMe')
 
     def test_get_sequencers_w_key_value(self):
         """Test get sequencers with given key-value pair in default config."""

--- a/metapool/tests/test_sequencers.py
+++ b/metapool/tests/test_sequencers.py
@@ -64,7 +64,7 @@ class TestSequencers(TestCase):
             get_model_by_instrument_id(
                 'LH1118920', sequencer_types=external_mapping)
 
-    def test_get_sequencer_type_name_and_run_center_by_instrument_code_by_model_prefix(self):
+    def test_get_sequencer_type_name_and_run_center_by_instrument_code_by_model_prefix(self):  # noqa
         obs = get_sequencer_type_name_and_run_center_by_instrument_code(
             'D32611_0365_G00DHB5YXX')
         self.assertEqual(obs, ('HiSeq2500', None))
@@ -73,7 +73,7 @@ class TestSequencers(TestCase):
             'A86753_0365_G00DHB5YXX')
         self.assertEqual(obs, ('NovaSeq6000', None))
 
-    def test_get_sequencer_type_name_and_run_center_by_instrument_code_by_instrument_id(self):
+    def test_get_sequencer_type_name_and_run_center_by_instrument_code_by_instrument_id(self):  # noqa
         obs = get_sequencer_type_name_and_run_center_by_instrument_code(
             'A00953_0032_AHWMGJDDXX')
         self.assertEqual(obs, ('NovaSeq6000', 'IGM'))
@@ -98,7 +98,7 @@ class TestSequencers(TestCase):
             'MN01225_0002_A000H2W3FY')
         self.assertEqual(obs, ('MiniSeq', 'CMI'))
 
-    def test_get_sequencer_type_name_and_run_center_by_instrument_code_by_model_prefix_err_no_match(self):
+    def test_get_sequencer_type_name_and_run_center_by_instrument_code_by_model_prefix_err_no_match(self):  # noqa
         err = "Unrecognized machine_prefix 'MQ'."
         with self.assertRaisesRegex(ValueError, err):
             get_sequencer_type_name_and_run_center_by_instrument_code(

--- a/metapool/tests/test_sequencers.py
+++ b/metapool/tests/test_sequencers.py
@@ -9,7 +9,7 @@ from unittest import TestCase, main
 
 
 class TestSequencers(TestCase):
-    def test__get_machine_code(self):
+    def test__get_machine_prefix(self):
         obs = _get_machine_prefix('K00180')
         self.assertEqual(obs, 'K')
 
@@ -19,8 +19,8 @@ class TestSequencers(TestCase):
         obs = _get_machine_prefix('MN01225')
         self.assertEqual(obs, 'MN')
 
-    def test__get_machine_code_err(self):
-        err = ("Cannot find a machine code; the instrument model "
+    def test__get_machine_prefix_err(self):
+        err = ("Cannot find a machine prefix; the instrument model "
                "'8675309' is malformed.")
         with self.assertRaisesRegex(ValueError, err):
             _get_machine_prefix('8675309')
@@ -38,7 +38,7 @@ class TestSequencers(TestCase):
 
     def test_get_model_by_instrument_id_err_none(self):
         """Test error when no model found for machine prefix."""
-        err = "Cannot find a machine code"
+        err = "Cannot find a machine prefix"
         with self.assertRaisesRegex(ValueError, err):
             get_model_by_instrument_id('MQ')
 


### PR DESCRIPTION
* Add platform and sequencing method to `sequencer_types.yml`
* Add code to `preparations_for_run` in `prep.py` to get platform and sequencing method from config rather than use hard-coded
    - NOTE: amplicon preps still use hardcoded
* Rename `prep.py`'s `parse_illumina_run_id` to `parse_run_id` and add ability to parse Revio run id